### PR TITLE
If the 2nd parameter of \MongoCollection::distinct() is empty, the resul...

### DIFF
--- a/Collection.php
+++ b/Collection.php
@@ -520,7 +520,13 @@ class Collection extends Object
         Yii::info($token, __METHOD__);
         try {
             Yii::beginProfile($token, __METHOD__);
-            $result = $this->mongoCollection->distinct($column, $condition);
+
+            if (empty($condition)) {
+                $result = $this->mongoCollection->distinct($column);
+            } else {
+                $result = $this->mongoCollection->distinct($column, $condition);
+            }
+
             Yii::endProfile($token, __METHOD__);
 
             return $result;


### PR DESCRIPTION
...t will be false when working with MongoDB 2.8.