### PR TITLE
Fix for #6153 Allow MongoDB cursor streaming via each()

### DIFF
--- a/ActiveQuery.php
+++ b/ActiveQuery.php
@@ -96,7 +96,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
     /**
      * @inheritdoc
      */
-    protected function buildCursor($db = null)
+    public function buildCursor($db = null)
     {
         if ($this->primaryModel !== null) {
             // lazy loading

--- a/BatchQueryResult.php
+++ b/BatchQueryResult.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\mongodb;
+
+use yii\base\Object;
+use yii\helpers\Json;
+use Yii;
+
+/**
+ * BatchQueryResult represents a batch query from which you can retrieve data in batches.
+ *
+ * You usually do not instantiate BatchQueryResult directly. Instead, you obtain it by
+ * calling [[Query::batch()]] or [[Query::each()]]. Because BatchQueryResult implements the `Iterator` interface,
+ * you can iterate it to obtain a batch of data in each iteration. For example,
+ *
+ * ```php
+ * $query = (new Query)->from('user');
+ * foreach ($query->batch() as $i => $users) {
+ *     // $users represents the rows in the $i-th batch
+ * }
+ * foreach ($query->each() as $user) {
+ * }
+ * ```
+ *
+ * @author Paul Klimov <klimov.paul@gmail.com>
+ * @since 2.0.4
+ */
+class BatchQueryResult extends Object implements \Iterator
+{
+    /**
+     * @var Connection the DB connection to be used when performing batch query.
+     * If null, the "db" application component will be used.
+     */
+    public $db;
+    /**
+     * @var Query the query object associated with this batch query.
+     * Do not modify this property directly unless after [[reset()]] is called explicitly.
+     */
+    public $query;
+    /**
+     * @var integer the number of rows to be returned in each batch.
+     */
+    public $batchSize = 100;
+    /**
+     * @var boolean whether to return a single row during each iteration.
+     * If false, a whole batch of rows will be returned in each iteration.
+     */
+    public $each = false;
+
+    /**
+     * @var array the data retrieved in the current batch
+     */
+    private $_batch;
+    /**
+     * @var mixed the value for the current iteration
+     */
+    private $_value;
+    /**
+     * @var string|integer the key for the current iteration
+     */
+    private $_key;
+    /**
+     * @var \MongoCursor
+     */
+    private $_cursor;
+
+
+    /**
+     * Resets the batch query.
+     * This method will clean up the existing batch query so that a new batch query can be performed.
+     */
+    public function reset()
+    {
+        $this->_cursor = null;
+        $this->_batch = null;
+        $this->_value = null;
+        $this->_key = null;
+    }
+
+    /**
+     * Resets the iterator to the initial state.
+     * This method is required by the interface Iterator.
+     */
+    public function rewind()
+    {
+        $this->reset();
+        $this->next();
+    }
+
+    /**
+     * Moves the internal pointer to the next dataset.
+     * This method is required by the interface Iterator.
+     */
+    public function next()
+    {
+        if ($this->_batch === null || !$this->each || $this->each && next($this->_batch) === false) {
+            $this->_batch = $this->fetchData();
+            reset($this->_batch);
+        }
+
+        if ($this->each) {
+            $this->_value = current($this->_batch);
+            if ($this->query->indexBy !== null) {
+                $this->_key = key($this->_batch);
+            } elseif (key($this->_batch) !== null) {
+                $this->_key++;
+            } else {
+                $this->_key = null;
+            }
+        } else {
+            $this->_value = $this->_batch;
+            $this->_key = $this->_key === null ? 0 : $this->_key + 1;
+        }
+    }
+
+    /**
+     * Fetches the next batch of data.
+     * @return array the data fetched
+     */
+    protected function fetchData()
+    {
+        if ($this->_cursor === null) {
+            $this->_cursor = $this->query->buildCursor($this->db);
+            if (empty($this->query->orderBy)) {
+                // setting cursor batch size may setup implicit limit on the query with 'sort'
+                // @see https://jira.mongodb.org/browse/PHP-457
+                $this->_cursor->batchSize($this->batchSize);
+            }
+            $token = 'find(' . Json::encode($this->_cursor->info()) . ')';
+            Yii::info($token, __METHOD__);
+        }
+
+        $rows = [];
+        $count = 0;
+        while ($count++ < $this->batchSize && ($row = $this->_cursor->getNext())) {
+            $rows[] = $row;
+        }
+        return $this->query->populate($rows);
+    }
+
+    /**
+     * Returns the index of the current dataset.
+     * This method is required by the interface Iterator.
+     * @return integer the index of the current row.
+     */
+    public function key()
+    {
+        return $this->_key;
+    }
+
+    /**
+     * Returns the current dataset.
+     * This method is required by the interface Iterator.
+     * @return mixed the current dataset.
+     */
+    public function current()
+    {
+        return $this->_value;
+    }
+
+    /**
+     * Returns whether there is a valid dataset at the current position.
+     * This method is required by the interface Iterator.
+     * @return boolean whether there is a valid dataset at the current position.
+     */
+    public function valid()
+    {
+        return !empty($this->_batch);
+    }
+} 

--- a/Query.php
+++ b/Query.php
@@ -100,7 +100,7 @@ class Query extends Component implements QueryInterface
      * @param Connection $db the database connection used to execute the query.
      * @return \MongoCursor mongo cursor instance.
      */
-    protected function buildCursor($db = null)
+    public function buildCursor($db = null)
     {
         $cursor = $this->getCollection($db)->find($this->composeCondition(), $this->composeSelectFields());
         if (!empty($this->orderBy)) {
@@ -127,7 +127,7 @@ class Query extends Component implements QueryInterface
         Yii::info($token, __METHOD__);
         try {
             Yii::beginProfile($token, __METHOD__);
-            $result = $this->fetchRowsInternal($cursor, $all, $indexBy);
+            $result = $this->fetchRowsInternal($cursor, $all);
             Yii::endProfile($token, __METHOD__);
 
             return $result;
@@ -140,11 +140,10 @@ class Query extends Component implements QueryInterface
     /**
      * @param \MongoCursor $cursor Mongo cursor instance to fetch data from.
      * @param boolean $all whether to fetch all rows or only first one.
-     * @param string|callable $indexBy value to index by.
      * @return array|boolean result.
      * @see Query::fetchRows()
      */
-    protected function fetchRowsInternal($cursor, $all, $indexBy)
+    protected function fetchRowsInternal($cursor, $all)
     {
         $result = [];
         if ($all) {
@@ -160,6 +159,67 @@ class Query extends Component implements QueryInterface
         }
 
         return $result;
+    }
+
+    /**
+     * Starts a batch query.
+     *
+     * A batch query supports fetching data in batches, which can keep the memory usage under a limit.
+     * This method will return a [[BatchQueryResult]] object which implements the `Iterator` interface
+     * and can be traversed to retrieve the data in batches.
+     *
+     * For example,
+     *
+     * ```php
+     * $query = (new Query)->from('user');
+     * foreach ($query->batch() as $rows) {
+     *     // $rows is an array of 10 or fewer rows from user collection
+     * }
+     * ```
+     *
+     * @param integer $batchSize the number of records to be fetched in each batch.
+     * @param Connection $db the MongoDB connection. If not set, the "mongodb" application component will be used.
+     * @return BatchQueryResult the batch query result. It implements the `Iterator` interface
+     * and can be traversed to retrieve the data in batches.
+     * @since 2.0.4
+     */
+    public function batch($batchSize = 100, $db = null)
+    {
+        return Yii::createObject([
+            'class' => BatchQueryResult::className(),
+            'query' => $this,
+            'batchSize' => $batchSize,
+            'db' => $db,
+            'each' => false,
+        ]);
+    }
+
+    /**
+     * Starts a batch query and retrieves data row by row.
+     * This method is similar to [[batch()]] except that in each iteration of the result,
+     * only one row of data is returned. For example,
+     *
+     * ```php
+     * $query = (new Query)->from('user');
+     * foreach ($query->each() as $row) {
+     * }
+     * ```
+     *
+     * @param integer $batchSize the number of records to be fetched in each batch.
+     * @param Connection $db the MongoDB connection. If not set, the "mongodb" application component will be used.
+     * @return BatchQueryResult the batch query result. It implements the `Iterator` interface
+     * and can be traversed to retrieve the data in batches.
+     * @since 2.0.4
+     */
+    public function each($batchSize = 100, $db = null)
+    {
+        return Yii::createObject([
+            'class' => BatchQueryResult::className(),
+            'query' => $this,
+            'batchSize' => $batchSize,
+            'db' => $db,
+            'each' => true,
+        ]);
     }
 
     /**

--- a/file/ActiveQuery.php
+++ b/file/ActiveQuery.php
@@ -72,7 +72,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
     /**
      * @inheritdoc
      */
-    protected function buildCursor($db = null)
+    public function buildCursor($db = null)
     {
         if ($this->primaryModel !== null) {
             // lazy loading

--- a/tests/BatchQueryResultTest.php
+++ b/tests/BatchQueryResultTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace yiiunit\extensions\mongodb;
+
+use yii\mongodb\BatchQueryResult;
+use yii\mongodb\Query;
+use yiiunit\extensions\mongodb\data\ar\ActiveRecord;
+use yiiunit\extensions\mongodb\data\ar\Customer;
+use yiiunit\extensions\mongodb\data\ar\CustomerOrder;
+
+/**
+ * @group mongodb
+ */
+class BatchQueryResultTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        ActiveRecord::$db = $this->getConnection();
+        $this->setUpTestRows();
+    }
+
+    protected function tearDown()
+    {
+        $this->dropCollection(Customer::collectionName());
+        $this->dropCollection(CustomerOrder::collectionName());
+        parent::tearDown();
+    }
+
+    /**
+     * Sets up test rows.
+     */
+    protected function setUpTestRows()
+    {
+        $customers = [];
+        for ($i = 1; $i <= 9; $i++) {
+            $customers[] = [
+                'name' => 'name' . $i,
+                'email' => 'email' . $i,
+                'address' => 'address' . $i,
+                'status' => $i,
+            ];
+        }
+        $customerCollection = $this->getConnection()->getCollection('customer');
+        $customers = $customerCollection->batchInsert($customers);
+
+        $customerOrders = [];
+        foreach ($customers as $i => $customer) {
+            $customerOrders[] = [
+                'customer_id' => $customer['_id'],
+                'number' => $customer['status'],
+            ];
+            $customerOrders[] = [
+                'customer_id' => $customer['_id'],
+                'number' => $customer['status'] + 100,
+            ];
+        }
+        $customerOrderCollection = $this->getConnection()->getCollection('customer_order');
+        $customerOrderCollection->batchInsert($customerOrders);
+    }
+
+    // Tests :
+
+    public function testQuery()
+    {
+        $db = $this->getConnection();
+
+        // initialize property test
+        $query = new Query();
+        $query->from('customer')->orderBy('id');
+        $result = $query->batch(2, $db);
+        $this->assertTrue($result instanceof BatchQueryResult);
+        $this->assertEquals(2, $result->batchSize);
+        $this->assertTrue($result->query === $query);
+
+        // normal query
+        $query = new Query();
+        $query->from('customer');
+        $allRows = [];
+        $batch = $query->batch(2, $db);
+        foreach ($batch as $rows) {
+            $allRows = array_merge($allRows, $rows);
+        }
+        $this->assertEquals(9, count($allRows));
+
+        // sorted query
+        $query = new Query();
+        $query->from('customer')->orderBy('name');
+        $allRows = [];
+        $batch = $query->batch(2, $db);
+        foreach ($batch as $rows) {
+            $allRows = array_merge($allRows, $rows);
+        }
+        $this->assertEquals(9, count($allRows));
+        $this->assertEquals('name1', $allRows[0]['name']);
+        $this->assertEquals('name2', $allRows[1]['name']);
+        $this->assertEquals('name3', $allRows[2]['name']);
+
+        // rewind
+        $allRows = [];
+        foreach ($batch as $rows) {
+            $allRows = array_merge($allRows, $rows);
+        }
+        $this->assertEquals(9, count($allRows));
+        // reset
+        $batch->reset();
+
+        // empty query
+        $query = new Query();
+        $query->from('customer')->where(['name' => 'unexistingName']);
+        $allRows = [];
+        $batch = $query->batch(2, $db);
+        foreach ($batch as $rows) {
+            $allRows = array_merge($allRows, $rows);
+        }
+        $this->assertEquals(0, count($allRows));
+
+        // query with index
+        $query = new Query();
+        $query->from('customer')->indexBy('name');
+        $allRows = [];
+        foreach ($query->batch(2, $db) as $rows) {
+            $allRows = array_merge($allRows, $rows);
+        }
+        $this->assertEquals(9, count($allRows));
+        $this->assertEquals('address1', $allRows['name1']['address']);
+        $this->assertEquals('address2', $allRows['name2']['address']);
+        $this->assertEquals('address3', $allRows['name3']['address']);
+
+        // each
+        $query = new Query();
+        $query->from('customer')->orderBy('name');
+        $allRows = [];
+        foreach ($query->each(100, $db) as $rows) {
+            $allRows[] = $rows;
+        }
+        $this->assertEquals(9, count($allRows));
+        $this->assertEquals('name1', $allRows[0]['name']);
+        $this->assertEquals('name2', $allRows[1]['name']);
+        $this->assertEquals('name3', $allRows[2]['name']);
+
+        // each with key
+        $query = new Query();
+        $query->from('customer')->orderBy('name')->indexBy('name');
+        $allRows = [];
+        foreach ($query->each(100, $db) as $key => $row) {
+            $allRows[$key] = $row;
+        }
+        $this->assertEquals(9, count($allRows));
+        $this->assertEquals('address1', $allRows['name1']['address']);
+        $this->assertEquals('address2', $allRows['name2']['address']);
+        $this->assertEquals('address3', $allRows['name3']['address']);
+    }
+
+    public function testActiveQuery()
+    {
+        $db = $this->getConnection();
+
+        $query = Customer::find()->orderBy('id');
+        $customers = [];
+        foreach ($query->batch(2, $db) as $models) {
+            $customers = array_merge($customers, $models);
+        }
+        $this->assertEquals(9, count($customers));
+        $this->assertEquals('name1', $customers[0]->name);
+        $this->assertEquals('name2', $customers[1]->name);
+        $this->assertEquals('name3', $customers[2]->name);
+
+        // batch with eager loading
+        $query = Customer::find()->with('orders')->orderBy('id');
+        $customers = [];
+        foreach ($query->batch(2, $db) as $models) {
+            $customers = array_merge($customers, $models);
+            foreach ($models as $model) {
+                $this->assertTrue($model->isRelationPopulated('orders'));
+            }
+        }
+        $this->assertEquals(9, count($customers));
+        $this->assertEquals(2, count($customers[0]->orders));
+        $this->assertEquals(2, count($customers[1]->orders));
+        $this->assertEquals(2, count($customers[2]->orders));
+    }
+}


### PR DESCRIPTION
Fix for https://github.com/yiisoft/yii2/issues/6153 Allow MongoDB cursor streaming via each()
Note: this enhancement breaks the BC cahnging the signature of `Query` methods.

Migrated from #9