### PR TITLE
update buildInCondition for array of one element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 mongodb extension Change Log
 - Enh #27: Added support for saving extra fields in session collection for `yii\mongodb\Session` (klimov-paul)
 - Enh #35: Added support for cursor options setup at `yii\mongodb\Query` (klimov-paul)
 - Enh #36: Added support for compare operators (like '>', '<' and so on) at `yii\mongodb\Query` (klimov-paul)
+- Enh #37: Now `yii\mongodb\Collection::buildInCondition` is not added '$in' for array contains one element (webdevsega)
 
 
 2.0.4 May 10, 2015

--- a/Collection.php
+++ b/Collection.php
@@ -1023,7 +1023,13 @@ class Collection extends Object
             } else {
                 $inValues = $values[$column];
             }
-            $result[$column][$operator] = array_values($inValues);
+
+            $inValues = array_values($inValues);
+            if (count($inValues) == 1) {
+                $result[$column] = $inValues[0];
+            } else {
+                $result[$column][$operator] = $inValues;
+            }
         }
 
         return $result;

--- a/Collection.php
+++ b/Collection.php
@@ -1025,7 +1025,7 @@ class Collection extends Object
             }
 
             $inValues = array_values($inValues);
-            if (count($inValues) == 1) {
+            if (count($inValues) === 1) {
                 $result[$column] = $inValues[0];
             } else {
                 $result[$column][$operator] = $inValues;


### PR DESCRIPTION
If array of values for the condition contains only one element, do not add the operator $in. Now when I use the relation 'hasOne' is always added $in with one value in the query.
This will improve the query performance.
