### PR TITLE
adding method getDriverName()

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -159,6 +159,15 @@ class Connection extends Component
     }
 
     /**
+     * Returns the name of the DB driver for the current [[dsn]].
+     * @return string name of the DB driver
+     */
+    public function getDriverName()
+    {
+        return 'mongodb';
+    }
+	
+    /**
      * Selects the database with given name.
      * @param string $name database name.
      * @return Database database instance.


### PR DESCRIPTION
This method is called when the Mongodb debug panel is opened and appears to exist in most other yii2 database Connection classes as well. 

Returns string `mongodb`.