### PR TITLE
Allow use of fields in nested documents as keys in relations

### DIFF
--- a/ActiveQuery.php
+++ b/ActiveQuery.php
@@ -221,4 +221,26 @@ class ActiveQuery extends Query implements ActiveQueryInterface
 
         return $models;
     }
+
+    /**
+     * @param ActiveRecord|array $model
+     * @param array $attributes
+     * @return string
+     */
+    private function getModelKey($model, $attributes)
+    {
+        $key = [];
+        foreach ($attributes as $attribute) {
+            while (($pos = strpos($attribute, '.'))) {
+                $model = $model[substr($attribute, 0, $pos)];
+                $attribute = substr($attribute, $pos + 1);
+            }
+            $key[] = $this->normalizeModelKey($model[$attribute]);
+        }
+        if (count($key) > 1) {
+            return serialize($key);
+        }
+        $key = reset($key);
+        return is_scalar($key) ? $key : serialize($key);
+    }
 }


### PR DESCRIPTION
Required if we have to get all files (without content) related to some documents. In this case we are recomended to use metadata field as a container for other fields. For example, Image model will have the following properties:
```javascript
{
    "metadata": {
        "post_id": ObjectId("abcd01234567890123456789"),
        "width": 640,
        "height": 480
    }
}
```
and relation in Post model can be declared like this
```php
public function getImages()
{
    return $this->hasMany(Image::className(), ['metadata.post_id' => '_id']);
}
```