### PR TITLE
fixes #69 by using same method as in yii\log\DbTarget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 mongodb extension Change Log
 - Enh #35: Added support for cursor options setup at `yii\mongodb\Query` (klimov-paul)
 - Enh #36: Added support for compare operators (like '>', '<' and so on) at `yii\mongodb\Query` (klimov-paul)
 - Enh #37: Now `yii\mongodb\Collection::buildInCondition` is not added '$in' for array contains one element (webdevsega)
+- Enh #69: Fixed log target to display exceptions like DbTarget in Yii core, also avoids problems with Exceptions that contain closures (cebe)
 
 
 2.0.4 May 10, 2015

--- a/log/MongoDbTarget.php
+++ b/log/MongoDbTarget.php
@@ -58,7 +58,12 @@ class MongoDbTarget extends Target
         foreach ($this->messages as $message) {
             list($text, $level, $category, $timestamp) = $message;
             if (!is_string($text)) {
-                $text = VarDumper::export($text);
+                // exceptions may not be serializable if in the call stack somewhere is a Closure
+                if ($text instanceof \Exception) {
+                    $text = (string) $text;
+                } else {
+                    $text = VarDumper::export($text);
+                }
             }
             $collection->insert([
                 'level' => $level,


### PR DESCRIPTION
fixes #69 by using same method as in yii\log\DbTarget

cast exception to string to have a readable representation.