### PR TITLE
Support ActiveRecord composite key relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Yii Framework 2 mongodb extension Change Log
 - Enh #36: Added support for compare operators (like '>', '<' and so on) at `yii\mongodb\Query` (klimov-paul)
 - Enh #37: Now `yii\mongodb\Collection::buildInCondition` is not added '$in' for array contains one element (webdevsega)
 - Enh #69: Fixed log target to display exceptions like DbTarget in Yii core, also avoids problems with Exceptions that contain closures (cebe)
+- Bug #73: Fixed ActiveRecord composite key relations (lennartvdd)
 
 
 2.0.4 May 10, 2015

--- a/Collection.php
+++ b/Collection.php
@@ -1008,11 +1008,11 @@ class Collection extends Object
         if (!is_array($column)) {
             $columns = [$column];
             $values = [$column => $values];
-        } elseif (count($column) < 2) {
-            $columns = $column;
-            $values = [$column[0] => $values];
+        } elseif (count($column) > 1) {
+            return $this->buildCompositeInCondition($operator, $column, $values);
         } else {
-            $columns = $column;
+        	$columns = $column;
+            $values = [$column[0] => $values];
         }
 
         $operator = $this->normalizeConditionKeyword($operator);
@@ -1032,6 +1032,32 @@ class Collection extends Object
             }
         }
 
+        return $result;
+    }
+
+    public function buildCompositeInCondition($operator, $columns, $values)
+    {
+    	$vss = [];
+        foreach ($values as $value) {
+            foreach ($columns as $column) {
+				if ($column == '_id') {
+	                $v = $this->ensureMongoId($value[$column]);
+	            } else {
+            		$v = $value[$column];
+	            }
+                $vss[$column][] = $v;
+            }
+        }
+
+        $result = [];
+        $operator = $this->normalizeConditionKeyword($operator);
+        foreach($vss as $column => $values) {
+        	if(count($values) === 1 && $operator === '$in') {
+        		$result[$column] = $values[0];
+        	} else {
+        	 	$result[$column][$operator] = $values;
+        	}
+        }
         return $result;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes, but did not work in the first place. Signature for in condition using multiple column in condition changed to match [`yii\db\QueryInterface::where()`](http://www.yiiframework.com/doc-2.0/yii-db-queryinterface.html#where()-detail)
| Tests pass?   | yes
| Fixed issues  | #73