### PR TITLE
fixed the value of '_id' is set to null when '_id' type is't ObjectId

### DIFF
--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -231,8 +231,10 @@ abstract class ActiveRecord extends BaseActiveRecord
             }
         }
         $newId = static::getCollection()->insert($values);
-        $this->setAttribute('_id', $newId);
-        $values['_id'] = $newId;
+        if($newId) {
+            $this->setAttribute('_id', $newId);
+            $values['_id'] = $newId;
+        }
 
         $changedAttributes = array_fill_keys(array_keys($values), null);
         $this->setOldAttributes($values);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| Tests pass?   | yes

fixed the value of '_id' is set to null when '_id' type is't ObjectId in ActiveRecord::insertInternal