### PR TITLE
Fixed `yii\mongodb\Query::exists()` always returning true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 mongodb extension Change Log
 2.1.2 under development
 -----------------------
 
-- no changes in this release.
+- Bug #150: Fixed Fixed `yii\mongodb\Query::exists()` always returning true (urmaul)
 
 
 2.1.1 August 29, 2016

--- a/Query.php
+++ b/Query.php
@@ -386,7 +386,7 @@ class Query extends Component implements QueryInterface
      */
     public function exists($db = null)
     {
-        return $this->one($db) !== null;
+        return $this->one($db) !== false;
     }
 
     /**

--- a/tests/QueryRunTest.php
+++ b/tests/QueryRunTest.php
@@ -368,4 +368,26 @@ class QueryRunTest extends TestCase
         $this->assertArrayNotHasKey('address', $row);
         $this->assertArrayNotHasKey('_id', $row);
     }
+    
+    public function testExists()
+    {
+        $connection = $this->getConnection();
+
+        $query = new Query();
+        $result = $query->from('customer')
+            ->where(['name' => 'name1'])
+            ->exists($connection);
+        $this->assertSame(true, $result);
+    }
+    
+    public function testNotExists()
+    {
+        $connection = $this->getConnection();
+
+        $query = new Query();
+        $result = $query->from('customer')
+            ->where(['name' => 'nonexistent'])
+            ->exists($connection);
+        $this->assertSame(false, $result);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #150 

