### PR TITLE
Added missing @since PHPDoc declaration

### DIFF
--- a/rbac/MongoDbManager.php
+++ b/rbac/MongoDbManager.php
@@ -472,6 +472,7 @@ class MongoDbManager extends BaseManager
 
     /**
      * @inheritdoc
+     * @since 2.1.2
      */
     public function getChildRoles($roleName)
     {


### PR DESCRIPTION
Благо многие занимающиеся этим расширением владеют русским, не буду заморачиваться с переводом. В нижеприведённом коммите добавлен новый метод, но он будет доступен только с версии 2.1.2, которая ещё не была релизнута. Мне, как человеку, привыкшему ориентироваться на генерируемую документацию, приятно в таком случае видеть соответствующую пометку напротив метода.
https://github.com/yiisoft/yii2-mongodb/commit/89ea4bee51590aea0d8eb26b75e234e63938f5be