### PR TITLE
Fixed #136: getChildRoles() throws an exception when role has no children

### DIFF
--- a/rbac/MongoDbManager.php
+++ b/rbac/MongoDbManager.php
@@ -482,7 +482,7 @@ class MongoDbManager extends BaseManager
             throw new InvalidParamException("Role '{$roleName}' not found.");
         }
 
-        /* @var $result Item[] */
+        $result = [];
         $this->getChildrenRecursive($roleName, $this->getChildrenList(), $result);
 
         $roles = [$roleName => $role];

--- a/tests/rbac/MongoDbManagerTest.php
+++ b/tests/rbac/MongoDbManagerTest.php
@@ -244,6 +244,9 @@ class MongoDbManagerTest extends TestCase
         $updateAnyPost->description = 'update any post';
         $this->auth->add($updateAnyPost);
 
+        $withoutChildren = $this->auth->createRole('withoutChildren');
+        $this->auth->add($withoutChildren);
+
         $reader = $this->auth->createRole('reader');
         $this->auth->add($reader);
         $this->auth->addChild($reader, $readPost);
@@ -312,6 +315,11 @@ class MongoDbManagerTest extends TestCase
     public function testGetChildRoles()
     {
         $this->prepareData();
+
+        $roles = $this->auth->getChildRoles('withoutChildren');
+        $this->assertCount(1, $roles);
+        $this->assertInstanceOf(Role::className(), reset($roles));
+        $this->assertTrue(reset($roles)->name === 'withoutChildren');
 
         $roles = $this->auth->getChildRoles('reader');
         $this->assertCount(1, $roles);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #161 
