### PR TITLE
Fix #171 : Added support for `QueryInterface::emulateExecution()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 mongodb extension Change Log
 
 - Bug #168: Fixed `yii\mongodb\Command::update()` uses `upsert` option by default (klimov-paul)
 - Bug #170: Fixed incorrect order of migrations history in case `yii\mongodb\console\controllers\MigrateController::$migrationNamespaces` is in use (klimov-paul)
+- Enh #171: Added support for `yii\db\QueryInterface::emulateExecution()` to force returning an empty result for a query (klimov-paul)
 
 
 2.1.2 October 31, 2016

--- a/Query.php
+++ b/Query.php
@@ -304,6 +304,9 @@ class Query extends Component implements QueryInterface
      */
     public function all($db = null)
     {
+        if ($this->emulateExecution) {
+            return [];
+        }
         $cursor = $this->buildCursor($db);
         $rows = $this->fetchRows($cursor, true, $this->indexBy);
         return $this->populate($rows);
@@ -337,11 +340,14 @@ class Query extends Component implements QueryInterface
      * Executes the query and returns a single row of result.
      * @param Connection $db the Mongo connection used to execute the query.
      * If this parameter is not given, the `mongodb` application component will be used.
-     * @return array|bool the first row (in terms of an array) of the query result. False is returned if the query
+     * @return array|false the first row (in terms of an array) of the query result. `false` is returned if the query
      * results in nothing.
      */
     public function one($db = null)
     {
+        if ($this->emulateExecution) {
+            return false;
+        }
         $cursor = $this->buildCursor($db);
         return $this->fetchRows($cursor, false);
     }
@@ -359,6 +365,10 @@ class Query extends Component implements QueryInterface
      */
     public function scalar($db = null)
     {
+        if ($this->emulateExecution) {
+            return null;
+        }
+
         $originSelect = (array)$this->select;
         if (!isset($originSelect['_id']) && array_search('_id', $originSelect, true) === false) {
             $this->select['_id'] = false;
@@ -385,6 +395,10 @@ class Query extends Component implements QueryInterface
      */
     public function column($db = null)
     {
+        if ($this->emulateExecution) {
+            return [];
+        }
+
         $originSelect = (array)$this->select;
         if (!isset($originSelect['_id']) && array_search('_id', $originSelect, true) === false) {
             $this->select['_id'] = false;
@@ -427,6 +441,10 @@ class Query extends Component implements QueryInterface
      */
     public function modify($update, $options = [], $db = null)
     {
+        if ($this->emulateExecution) {
+            return null;
+        }
+
         $collection = $this->getCollection($db);
         if (!empty($this->orderBy)) {
             $options['sort'] = $this->orderBy;
@@ -446,6 +464,9 @@ class Query extends Component implements QueryInterface
      */
     public function count($q = '*', $db = null)
     {
+        if ($this->emulateExecution) {
+            return 0;
+        }
         $collection = $this->getCollection($db);
         return $collection->count($this->where, $this->options);
     }
@@ -471,6 +492,9 @@ class Query extends Component implements QueryInterface
      */
     public function sum($q, $db = null)
     {
+        if ($this->emulateExecution) {
+            return 0;
+        }
         return $this->aggregate($q, 'sum', $db);
     }
 
@@ -484,6 +508,9 @@ class Query extends Component implements QueryInterface
      */
     public function average($q, $db = null)
     {
+        if ($this->emulateExecution) {
+            return 0;
+        }
         return $this->aggregate($q, 'avg', $db);
     }
 
@@ -522,6 +549,10 @@ class Query extends Component implements QueryInterface
      */
     protected function aggregate($column, $operator, $db)
     {
+        if ($this->emulateExecution) {
+            return null;
+        }
+
         $collection = $this->getCollection($db);
         $pipelines = [];
         if ($this->where !== null) {
@@ -538,9 +569,8 @@ class Query extends Component implements QueryInterface
         $result = $collection->aggregate($pipelines);
         if (array_key_exists(0, $result)) {
             return $result[0]['total'];
-        } else {
-            return 0;
         }
+        return null;
     }
 
     /**
@@ -552,6 +582,10 @@ class Query extends Component implements QueryInterface
      */
     public function distinct($q, $db = null)
     {
+        if ($this->emulateExecution) {
+            return [];
+        }
+
         $collection = $this->getCollection($db);
         if ($this->where !== null) {
             $condition = $this->where;
@@ -561,9 +595,8 @@ class Query extends Component implements QueryInterface
         $result = $collection->distinct($q, $condition);
         if ($result === false) {
             return [];
-        } else {
-            return $result;
         }
+        return $result;
     }
 
     /**
@@ -574,8 +607,7 @@ class Query extends Component implements QueryInterface
     {
         if ($this->where === null) {
             return [];
-        } else {
-            return $this->where;
         }
+        return $this->where;
     }
 }

--- a/Query.php
+++ b/Query.php
@@ -304,7 +304,7 @@ class Query extends Component implements QueryInterface
      */
     public function all($db = null)
     {
-        if ($this->emulateExecution) {
+        if (!empty($this->emulateExecution)) {
             return [];
         }
         $cursor = $this->buildCursor($db);
@@ -345,7 +345,7 @@ class Query extends Component implements QueryInterface
      */
     public function one($db = null)
     {
-        if ($this->emulateExecution) {
+        if (!empty($this->emulateExecution)) {
             return false;
         }
         $cursor = $this->buildCursor($db);
@@ -365,7 +365,7 @@ class Query extends Component implements QueryInterface
      */
     public function scalar($db = null)
     {
-        if ($this->emulateExecution) {
+        if (!empty($this->emulateExecution)) {
             return null;
         }
 
@@ -395,7 +395,7 @@ class Query extends Component implements QueryInterface
      */
     public function column($db = null)
     {
-        if ($this->emulateExecution) {
+        if (!empty($this->emulateExecution)) {
             return [];
         }
 
@@ -441,7 +441,7 @@ class Query extends Component implements QueryInterface
      */
     public function modify($update, $options = [], $db = null)
     {
-        if ($this->emulateExecution) {
+        if (!empty($this->emulateExecution)) {
             return null;
         }
 
@@ -464,7 +464,7 @@ class Query extends Component implements QueryInterface
      */
     public function count($q = '*', $db = null)
     {
-        if ($this->emulateExecution) {
+        if (!empty($this->emulateExecution)) {
             return 0;
         }
         $collection = $this->getCollection($db);
@@ -492,7 +492,7 @@ class Query extends Component implements QueryInterface
      */
     public function sum($q, $db = null)
     {
-        if ($this->emulateExecution) {
+        if (!empty($this->emulateExecution)) {
             return 0;
         }
         return $this->aggregate($q, 'sum', $db);
@@ -508,7 +508,7 @@ class Query extends Component implements QueryInterface
      */
     public function average($q, $db = null)
     {
-        if ($this->emulateExecution) {
+        if (!empty($this->emulateExecution)) {
             return 0;
         }
         return $this->aggregate($q, 'avg', $db);
@@ -549,7 +549,7 @@ class Query extends Component implements QueryInterface
      */
     protected function aggregate($column, $operator, $db)
     {
-        if ($this->emulateExecution) {
+        if (!empty($this->emulateExecution)) {
             return null;
         }
 
@@ -582,7 +582,7 @@ class Query extends Component implements QueryInterface
      */
     public function distinct($q, $db = null)
     {
-        if ($this->emulateExecution) {
+        if (!empty($this->emulateExecution)) {
             return [];
         }
 

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -436,6 +436,10 @@ class ActiveRecordTest extends TestCase
 
     public function testEmulateExecution()
     {
+        if (!Customer::find()->hasMethod('emulateExecution')) {
+            $this->markTestSkipped('"yii2" version 2.0.11 or higher required');
+        }
+
         $this->assertGreaterThan(0, Customer::find()->from('customer')->count());
 
         $rows = Customer::find()

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -433,4 +433,85 @@ class ActiveRecordTest extends TestCase
 
         $this->assertEquals('custom', $record->_id);
     }
+
+    public function testEmulateExecution()
+    {
+        $this->assertGreaterThan(0, Customer::find()->from('customer')->count());
+
+        $rows = Customer::find()
+            ->from('customer')
+            ->emulateExecution()
+            ->all();
+        $this->assertSame([], $rows);
+
+        $row = Customer::find()
+            ->from('customer')
+            ->emulateExecution()
+            ->one();
+        $this->assertSame(null, $row);
+
+        $exists = Customer::find()
+            ->from('customer')
+            ->emulateExecution()
+            ->exists();
+        $this->assertSame(false, $exists);
+
+        $count = Customer::find()
+            ->from('customer')
+            ->emulateExecution()
+            ->count();
+        $this->assertSame(0, $count);
+
+        $sum = Customer::find()
+            ->from('customer')
+            ->emulateExecution()
+            ->sum('id');
+        $this->assertSame(0, $sum);
+
+        $sum = Customer::find()
+            ->from('customer')
+            ->emulateExecution()
+            ->average('id');
+        $this->assertSame(0, $sum);
+
+        $max = Customer::find()
+            ->from('customer')
+            ->emulateExecution()
+            ->max('id');
+        $this->assertSame(null, $max);
+
+        $min = Customer::find()
+            ->from('customer')
+            ->emulateExecution()
+            ->min('id');
+        $this->assertSame(null, $min);
+
+        $scalar = Customer::find()
+            ->select(['id'])
+            ->from('customer')
+            ->emulateExecution()
+            ->scalar();
+        $this->assertSame(null, $scalar);
+
+        $column = Customer::find()
+            ->select(['id'])
+            ->from('customer')
+            ->emulateExecution()
+            ->column();
+        $this->assertSame([], $column);
+
+        $row = Customer::find()
+            ->select(['id'])
+            ->from('customer')
+            ->emulateExecution()
+            ->modify(['name' => 'new name']);
+        $this->assertSame(null, $row);
+
+        $values = Customer::find()
+            ->select(['id'])
+            ->from('customer')
+            ->emulateExecution()
+            ->distinct('name');
+        $this->assertSame([], $values);
+    }
 }

--- a/tests/QueryRunTest.php
+++ b/tests/QueryRunTest.php
@@ -496,4 +496,87 @@ class QueryRunTest extends TestCase
             ->column($connection);
         $this->assertEquals(['name1' => 'name1', 'name10' => 'name10'], $result);
     }
+
+    public function testEmulateExecution()
+    {
+        $db = $this->getConnection();
+
+        $this->assertGreaterThan(0, (new Query())->from('customer')->count('*', $db));
+
+        $rows = (new Query())
+            ->from('customer')
+            ->emulateExecution()
+            ->all($db);
+        $this->assertSame([], $rows);
+
+        $row = (new Query())
+            ->from('customer')
+            ->emulateExecution()
+            ->one($db);
+        $this->assertSame(false, $row);
+
+        $exists = (new Query())
+            ->from('customer')
+            ->emulateExecution()
+            ->exists($db);
+        $this->assertSame(false, $exists);
+
+        $count = (new Query())
+            ->from('customer')
+            ->emulateExecution()
+            ->count('*', $db);
+        $this->assertSame(0, $count);
+
+        $sum = (new Query())
+            ->from('customer')
+            ->emulateExecution()
+            ->sum('id', $db);
+        $this->assertSame(0, $sum);
+
+        $sum = (new Query())
+            ->from('customer')
+            ->emulateExecution()
+            ->average('id', $db);
+        $this->assertSame(0, $sum);
+
+        $max = (new Query())
+            ->from('customer')
+            ->emulateExecution()
+            ->max('id', $db);
+        $this->assertSame(null, $max);
+
+        $min = (new Query())
+            ->from('customer')
+            ->emulateExecution()
+            ->min('id', $db);
+        $this->assertSame(null, $min);
+
+        $scalar = (new Query())
+            ->select(['id'])
+            ->from('customer')
+            ->emulateExecution()
+            ->scalar($db);
+        $this->assertSame(null, $scalar);
+
+        $column = (new Query())
+            ->select(['id'])
+            ->from('customer')
+            ->emulateExecution()
+            ->column($db);
+        $this->assertSame([], $column);
+
+        $row = (new Query())
+            ->select(['id'])
+            ->from('customer')
+            ->emulateExecution()
+            ->modify(['name' => 'new name'], [], $db);
+        $this->assertSame(null, $row);
+
+        $values = (new Query())
+            ->select(['id'])
+            ->from('customer')
+            ->emulateExecution()
+            ->distinct('name', $db);
+        $this->assertSame([], $values);
+    }
 }

--- a/tests/QueryRunTest.php
+++ b/tests/QueryRunTest.php
@@ -499,9 +499,14 @@ class QueryRunTest extends TestCase
 
     public function testEmulateExecution()
     {
+        $query = new Query();
+        if (!$query->hasMethod('emulateExecution')) {
+            $this->markTestSkipped('"yii2" version 2.0.11 or higher required');
+        }
+
         $db = $this->getConnection();
 
-        $this->assertGreaterThan(0, (new Query())->from('customer')->count('*', $db));
+        $this->assertGreaterThan(0, $query->from('customer')->count('*', $db));
 
         $rows = (new Query())
             ->from('customer')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #171

Should be merged after `yii2` 2.0.11 release