### PR TITLE
Setting unknow property issue

### DIFF
--- a/rbac/MongoDbManager.php
+++ b/rbac/MongoDbManager.php
@@ -907,7 +907,6 @@ class MongoDbManager extends BaseManager
             $this->cache->delete($this->cacheKey);
             $this->items = null;
             $this->rules = null;
-            $this->parents = null;
         }
     }
 


### PR DESCRIPTION
Setting unknown property: yii\mongodb\rbac\MongoDbManager::parents

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | fix issue of Setting unknown property: yii\mongodb\rbac\MongoDbManager::parents
