### PR TITLE
Add `MongoIdValidator::expectArray` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 mongodb extension Change Log
 -----------------------
 
 - Bug #187: Fixed exception is thrown on `yii\mongodb\rbac\MongoDbManager::invalidateCache()` invocation (jafaripur)
+- Enh: Added `yii\mongodb\validators\MongoIdValidator::expectArray` allowing to validate and force format on an array of Mongo IDs (elkesu)
 
 
 2.1.3 February 15, 2017

--- a/tests/validators/MongoIdValidatorTest.php
+++ b/tests/validators/MongoIdValidatorTest.php
@@ -2,7 +2,6 @@
 
 namespace yiiunit\extensions\mongodb\validators;
 
-use MongoDB\BSON\ObjectID;
 use yii\base\Model;
 use yii\mongodb\validators\MongoIdValidator;
 use yiiunit\extensions\mongodb\TestCase;
@@ -19,8 +18,9 @@ class MongoIdValidatorTest extends TestCase
     {
         $validator = new MongoIdValidator();
         $this->assertFalse($validator->validate('id'));
-        $this->assertTrue($validator->validate(new ObjectID('4d3ed089fb60ab534684b7e9')));
-        $this->assertTrue($validator->validate('4d3ed089fb60ab534684b7e9'));
+        $this->assertTrue($validator->validate(MongoIdTestModel::$objectId));
+        $this->assertTrue($validator->validate(MongoIdTestModel::$stringId));
+        $this->assertFalse($validator->validate([MongoIdTestModel::$stringId]));
     }
 
     public function testValidateAttribute()
@@ -32,10 +32,22 @@ class MongoIdValidatorTest extends TestCase
 
         $model->id = 'id';
         $this->assertFalse($model->validate());
-        $model->id = new ObjectID('4d3ed089fb60ab534684b7e9');
+        $model->id = $model::$objectId;
         $this->assertTrue($model->validate());
-        $model->id = '4d3ed089fb60ab534684b7e9';
+        $model->id = $model::$stringId;
         $this->assertTrue($model->validate());
+
+        $validator->attributes = ['ids'];
+        $model->ids = [$model::$stringId];
+        $this->assertFalse($model->validate());
+        $validator->expectArray = true;
+        $this->assertTrue($model->validate());
+        array_push($model->ids, $model::$objectId);
+        $this->assertTrue($model->validate());
+        array_push($model->ids, 'id');
+        $this->assertFalse($model->validate());
+        $model->ids = $model::$stringId;
+        $this->assertFalse($model->validate());
     }
 
     /**
@@ -49,26 +61,57 @@ class MongoIdValidatorTest extends TestCase
         $model->getValidators()->append($validator);
 
         $validator->forceFormat = null;
-        $model->id = '4d3ed089fb60ab534684b7e9';
+        $model->id = $model::$stringId;
         $model->validate();
-        $this->assertTrue(is_string($model->id));
-        $model->id = new ObjectID('4d3ed089fb60ab534684b7e9');
+        $this->assertInternalType('string', $model->id);
+        $model->id = $model::$objectId;
         $model->validate();
-        $this->assertTrue($model->id instanceof ObjectID);
+        $this->assertInstanceOf($model::$objectIdClass, $model->id);
 
         $validator->forceFormat = 'object';
-        $model->id = '4d3ed089fb60ab534684b7e9';
+        $model->id = $model::$stringId;
         $model->validate();
-        $this->assertTrue($model->id instanceof ObjectID);
+        $this->assertInstanceOf($model::$objectIdClass, $model->id);
 
         $validator->forceFormat = 'string';
-        $model->id = new ObjectID('4d3ed089fb60ab534684b7e9');
+        $model->id = $model::$objectId;
         $model->validate();
-        $this->assertTrue(is_string($model->id));
+        $this->assertInternalType('string', $model->id);
+
+        $validator->attributes = ['ids'];
+        $validator->expectArray = true;
+        $model->ids = [$model::$stringId, $model::$objectId];
+
+        $validator->forceFormat = null;
+        $model->validate();
+        $this->assertSame($model::$stringId, $model->ids[0]);
+        $this->assertSame($model::$objectId, $model->ids[1]);
+
+        $validator->forceFormat = 'object';
+        $model->validate();
+        $this->assertInstanceOf($model::$objectIdClass, $model->ids[0]);
+        $this->assertInstanceOf($model::$objectIdClass, $model->ids[1]);
+
+        $validator->forceFormat = 'string';
+        $model->ids = [$model::$stringId, $model::$objectId];
+        $model->validate();
+        $this->assertInternalType('string', $model->ids[0]);
+        $this->assertInternalType('string', $model->ids[1]);
     }
 }
 
 class MongoIdTestModel extends Model
 {
+    public static $stringId = '4d3ed089fb60ab534684b7e9';
+    public static $objectId;
+    public static $objectIdClass = '\MongoDB\BSON\ObjectID';
+
     public $id;
+    public $ids;
+
+    public function init()
+    {
+        parent::init();
+        self::$objectId = new self::$objectIdClass(self::$stringId);
+    }
 }


### PR DESCRIPTION
This is the enhancement to MongoIdValidator, which I needed for a project. It allows to validate an array of ids coming from a form (for instance, an array of tags for an article) and convert each id to Mongo ID before saving to DB without repeated conversion in afterValidate() or beforeSave().

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 
