### PR TITLE
Unsetting limit in Command::find when it is less than 1.

### DIFF
--- a/Command.php
+++ b/Command.php
@@ -597,7 +597,7 @@ class Command extends Object
         }
 
         if (array_key_exists('limit', $options)) {
-            if ($options['limit'] === null) {
+            if ($options['limit'] === null || $options['limit'] < 1) {
                 unset($options['limit']);
             } else {
                 $options['limit'] = (int)$options['limit'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 203
