### PR TITLE
Changing DSN structure guide in README to prevent issues for special passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ return [
     'components' => [
         'mongodb' => [
             'class' => '\yii\mongodb\Connection',
-            'dsn' => 'mongodb://developer:password@localhost:27017/mydatabase',
+            'dsn' => 'mongodb://@localhost:27017/mydatabase',
+            'options' => [
+                "username" => "Username",
+                "password" => "Password"
+            ]
         ],
     ],
 ];


### PR DESCRIPTION
Connecting to MongoDb this way will prevent error in DSN for passwords with special characters like "@".

P.S: I had an issue for connecting to MongoDb because my password's first character was "@" and it has been mistaken by the "@" before localhost so I couldn't get connected (strange error occurred).
I have been struggling hours to find a way that the "options" parameter in configuration exists to send username and password outside of the DSN string. I think this is a better way to get connected without any problems no matter what your password contains.