### PR TITLE
Added default 'cursor' option to fix MongoDB 3.6 aggregation

### DIFF
--- a/Command.php
+++ b/Command.php
@@ -728,15 +728,18 @@ class Command extends BaseObject
      */
     public function aggregate($collectionName, $pipelines, $options = [])
     {
-        $this->document = $this->db->getQueryBuilder()->aggregate($collectionName, $pipelines, $options);
+        $opts = $options;
+        if ($opts === [] || !isset($opts['explain'], $opts['cursor'])) {
+            $opts['cursor'] = ['batchSize' => 101];
+        }
+
+        $this->document = $this->db->getQueryBuilder()->aggregate($collectionName, $pipelines, $opts);
         $cursor = $this->execute();
 
         if (!empty($options['cursor'])) {
             return $cursor;
         }
-        $result = current($cursor->toArray());
-
-        return $result['result'];
+        return $cursor->toArray();
     }
 
     /**


### PR DESCRIPTION
New MongoDB 3.6 restrictions: aggregate method should use cursor option. Otherwise we get the following exception: The 'cursor' option is required, except for aggregate with the explain argument

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #241 
