### PR TITLE
fix ActiveQuery constructor PhpDocs

### DIFF
--- a/src/ActiveQuery.php
+++ b/src/ActiveQuery.php
@@ -72,7 +72,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
 
     /**
      * Constructor.
-     * @param array $modelClass the model class associated with this query
+     * @param string $modelClass the model class associated with this query
      * @param array $config configurations to be applied to the newly created query object
      */
     public function __construct($modelClass, $config = [])


### PR DESCRIPTION
Invocation parameter types are not compatible with declared.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | no
