### PR TITLE
Fix sessionWrite callback fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 mongodb extension Change Log
 2.1.8 under development
 -----------------------
 
-- no changes in this release.
+- fix sessionWrite callback fields (related to https://github.com/yiisoft/yii2/issues/17559 and https://github.com/yiisoft/yii2/pull/17188)
 
 
 2.1.7 March 30, 2018

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 mongodb extension Change Log
 2.1.8 under development
 -----------------------
 
-- fix sessionWrite callback fields (related to https://github.com/yiisoft/yii2/issues/17559 and https://github.com/yiisoft/yii2/pull/17188)
+- Bug #285: Fix `sessionWrite` callback fields (related to https://github.com/yiisoft/yii2/issues/17559 and https://github.com/yiisoft/yii2/pull/17188) (lubosdz)
 
 
 2.1.7 March 30, 2018


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | https://github.com/yiisoft/yii2/issues/17559

This is quite unfortunate cross-package issue, may affect also other databases (only if using session writeCallback). Currently are fixed mysql, mongo, not sure about other RDBMS. New property `fields` should go actually into `MultiFieldSession` since it's parent class for all databases. Currently, for faster fix is `fields` added directly into child class.