### PR TITLE
Fix #286: Fix `Collection::dropAllIndexes()` error when no indexes were dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 mongodb extension Change Log
 2.1.9 under development
 -----------------------
 
-- no changes in this release.
+- Bug #286: Fix `Collection::dropAllIndexes()` error when no indexes were dropped (samdark)
 
 
 2.1.8 October 08, 2019

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -206,7 +206,7 @@ class Collection extends BaseObject
     public function dropAllIndexes()
     {
         $result = $this->database->createCommand()->dropIndexes($this->name, '*');
-        return $result['nIndexesWas'];
+        return isset($result['nIndexesWas']) ? $result['nIndexesWas'] : 0;
     }
 
     /**


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #286
