### PR TITLE
Migration config for more than one DB engine

### DIFF
--- a/docs/guide/topics-migrations.md
+++ b/docs/guide/topics-migrations.md
@@ -30,3 +30,26 @@ yii mongodb-migrate
 # reverts the last applied migration
 yii mongodb-migrate/down
 ```
+## Special configuration for an application that uses more than one DB engine
+
+In case your application uses multiple databases, example:  
+
+- MySQL + MongoDB
+
+If you run the migration commands, it will evaluate both MySQL and MongoDB migration files at the same time since both by default share the same folder.
+
+**Problem: MongoDB will try to run MySQL's migration files and the other way around.**
+
+In order to avoid that behavior, you can create a new folder called `mongodb` under your `migrations` folder, and then setup your console application like this:
+
+```php
+return [
+    // ...
+    'controllerMap' => [
+        'mongodb-migrate' => [
+          'class' => 'yii\mongodb\console\controllers\MigrateController',
+          'migrationPath' => '@app/migrations/mongodb',
+        ],
+    ],
+];
+```


### PR DESCRIPTION
Special configuration for an application that uses more than one DB engine to avoid mixing migrations from both systems.

The problem it solves:  

- If you run both MySQL and MongoDB and have migrations for both, with the default configuration if you create a mongodb migration and try to run it, it will tell you that you have a lot of other pending migrations, that are actually MySQL migrations.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
