### PR TITLE
Active Record flexible batch operations(Insert,Update,Delete)

### DIFF
--- a/src/ActiveRecord.php
+++ b/src/ActiveRecord.php
@@ -498,10 +498,8 @@ abstract class ActiveRecord extends BaseActiveRecord
     public function batchUpdate():void{
         self::batchUpdateInit();
         $values = $this->getDirtyAttributes($attributes);
-        if (empty($values)) {
-            $this->afterSave(false, $values);
-            return 0;
-        }
+        if (empty($values))
+           return;
         $condition = $this->getOldPrimaryKey(true);
         self::$batchUpdateCommand->AddUpdate($condition, $values);
         self::$batchUpdateQueue++;
@@ -536,8 +534,7 @@ abstract class ActiveRecord extends BaseActiveRecord
 
     public function batchDelete():void{
         self::batchDeleteInit();
-        $condition = $this->getOldPrimaryKey(true);
-        self::$batchDeleteCommand->AddDelete($condition);
+        self::$batchDeleteCommand->AddDelete($this->getOldPrimaryKey(true));
         self::$batchDeleteQueue++;
         if(self::$batchDeleteQueue >= self::$batchDeleteSize)
             self::flushBatchDelete();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | in development...

```php
MyActiveRecord::$batchInsertSize = 1000;
foreach($myData as $data){
    $obj = new MyActiveRecord();
    $obj->field1 = 'data1';
    $obj->field2 = 'data2';
    $obj->field3 = 'data3';
    $obj->batchSave(); #or batchInsert();
    #no any database operation execute until count of insert operation equal MyActiveRecord::$batchInsertSize
}
MyActiveRecord::flushBatchInsert(); // executing the remaining operations. required.
```

or `batchDelete()` or `batchUpdate`