### PR TITLE
using ActiveQuery::Exists() method in friendly mode

### DIFF
--- a/src/ActiveRecord.php
+++ b/src/ActiveRecord.php
@@ -411,4 +411,15 @@ abstract class ActiveRecord extends BaseActiveRecord
         }
         return ArrayHelper::toArray($object);
     }
+
+    /**
+     * using ActiveQuery::exists() method in friendly mode
+     * @param reference $object if passed then object returned based on conditions , else only checked existence in database
+     * @return bool return true if $conditions exists in database
+     */
+    public static function exists($conditions, &$object = null):bool{
+        if(func_num_args() === 2)
+            return ($object = self::findOne($conditions)) ? true : false;
+        return self::find()->where($conditions)->exists();
+    }
 }

--- a/src/ActiveRecord.php
+++ b/src/ActiveRecord.php
@@ -417,7 +417,7 @@ abstract class ActiveRecord extends BaseActiveRecord
      * @param reference $object if passed then object returned based on conditions , else only checked existence in database
      * @return bool return true if $conditions exists in database
      */
-    public static function exists($conditions, &$object = null):bool{
+    public static function exists($conditions, &$object = null){
         if(func_num_args() === 2)
             return ($object = self::findOne($conditions)) ? true : false;
         return self::find()->where($conditions)->exists();

--- a/src/ActiveRecord.php
+++ b/src/ActiveRecord.php
@@ -419,7 +419,7 @@ abstract class ActiveRecord extends BaseActiveRecord
      */
     public static function exists($conditions, &$object = null){
         if(func_num_args() === 2)
-            return ($object = self::findOne($conditions)) ? true : false;
+            return ($object = self::find()->where($conditions)->one()) ? true : false;
         return self::find()->where($conditions)->exists();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes

example (fetch document from database)
```php
if(!MyActiveRecord::exists(['my condition for pass to where()']),$myRecord)
    return false;
$myRecord->field1 = 'value';
```
example (no fetch document from database)
```php
if(!MyActiveRecord::exists(['my condition for pass to where()']))
    return false;
```

this PR is efficient when [that PR](https://github.com/yiisoft/yii2-mongodb/pull/298) committed.