### PR TITLE
Dont select

### DIFF
--- a/src/ActiveQuery.php
+++ b/src/ActiveQuery.php
@@ -219,4 +219,17 @@ class ActiveQuery extends Query implements ActiveQueryInterface
 
         return parent::populate($models);
     }
+
+    /**
+     * do not select some fields
+     * @param array $fields list of fields name that you not want selected them
+     * @return $this the query object itself.
+     */
+    public function dontSelect(array $fields)
+    {
+        $model = new $this->modelClass;
+        $this->select = array_diff($model->attributes(),$fields);
+
+        return $this;
+    }
 }

--- a/src/ActiveQuery.php
+++ b/src/ActiveQuery.php
@@ -222,7 +222,7 @@ class ActiveQuery extends Query implements ActiveQueryInterface
 
     /**
      * do not select some fields
-     * @param array $fields list of fields name that you not want selected them
+     * @param array $fields name list of fields that you dont want to select them
      * @return $this the query object itself.
      */
     public function dontSelect(array $fields)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes

data structure in `mongodb` for storing is [BSON](https://docs.mongodb.com/manual/reference/bson-types/). [embedded document](https://docs.mongodb.com/manual/core/data-model-design/#data-modeling-embedding) is a good feature in `mongodb` and maximum document size is `16 MB`.
All of these show that a document in `mongodb` can be large and that the `dontSelect()` feature can help you in not selecting large unused fields.

```php
$users =
    user::find()
        ->dontSelect(['profileImage'])
        ->limit(10)
    ->all()
;
```