### PR TITLE
Open files read-only for upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 mongodb extension Change Log
 2.1.10 under development
 ------------------------
 
-- Bug #308: Fix ` yii\mongodb\file\Upload::addFile()` error when uploading file with readonly permissions (sparchatus)
+- Bug #308: Fix `yii\mongodb\file\Upload::addFile()` error when uploading file with readonly permissions (sparchatus)
 
 
 2.1.9 November 19, 2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 mongodb extension Change Log
 2.1.10 under development
 ------------------------
 
-- no changes in this release.
+- Bug #308: Fix ` yii\mongodb\file\Upload::addFile()` error when uploading file with readonly permissions (sparchatus)
 
 
 2.1.9 November 19, 2019

--- a/src/file/Upload.php
+++ b/src/file/Upload.php
@@ -178,7 +178,7 @@ class Upload extends BaseObject
             $this->filename = basename($filename);
         }
 
-        $stream = fopen($filename, 'r+');
+        $stream = fopen($filename, 'r');
         if ($stream === false) {
             throw new InvalidParamException("Unable to read file '{$filename}'");
         }


### PR DESCRIPTION
The issue described in https://github.com/yiisoft/yii2-mongodb/issues/308 appears to be fixed with this change

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | 308
