### PR TITLE
Use `random_int()` for cache garbage collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 mongodb extension Change Log
 2.1.12 under development
 ------------------------
 
-- no changes in this release.
+- Enh: Use `random_int()` for cache garbage collection (samdark)
 
 
 2.1.11 December 23, 2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 mongodb extension Change Log
 2.1.12 under development
 ------------------------
 
-- Enh: Use `random_int()` for cache garbage collection (samdark)
+- Enh #342: Use `random_int()` for cache garbage collection (samdark)
 
 
 2.1.11 December 23, 2020

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "yiisoft/yii2": "~2.0.39",
         "ext-mongodb": ">=1.0.0",
-        "paragonie/random_compat": "^2.0"
+        "paragonie/random_compat": ">=1"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.27|~5.7.21|^6.2"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     ],
     "require": {
         "yiisoft/yii2": "~2.0.39",
-        "ext-mongodb": ">=1.0.0"
+        "ext-mongodb": ">=1.0.0",
+        "paragonie/random_compat": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.27|~5.7.21|^6.2"

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -185,7 +185,8 @@ class Cache extends \yii\caching\Cache
      */
     public function gc($force = false)
     {
-        if ($force || mt_rand(0, 1000000) < $this->gcProbability) {
+
+        if ($force || random_int(0, 1000000) < $this->gcProbability) {
             $this->db->getCollection($this->cacheCollection)
                 ->remove([
                     'expire' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | related to https://github.com/yiisoft/yii2/pull/18817
