### PR TITLE
adds 8.1 support to

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: ['7.0', '7.1', '7.2', '7.3', '7.4']
+                php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
                 mongo: ['3']
                 mongoext: ['1.8.2', '1.9.0']
 

--- a/src/BatchQueryResult.php
+++ b/src/BatchQueryResult.php
@@ -73,7 +73,7 @@ class BatchQueryResult extends BaseObject implements \Iterator
      * Resets the batch query.
      * This method will clean up the existing batch query so that a new batch query can be performed.
      */
-    public function reset()
+    public function reset(): void
     {
         $this->_iterator = null;
         $this->_batch = null;
@@ -85,7 +85,7 @@ class BatchQueryResult extends BaseObject implements \Iterator
      * Resets the iterator to the initial state.
      * This method is required by the interface Iterator.
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->reset();
         $this->next();
@@ -95,7 +95,7 @@ class BatchQueryResult extends BaseObject implements \Iterator
      * Moves the internal pointer to the next dataset.
      * This method is required by the interface Iterator.
      */
-    public function next()
+    public function next(): void
     {
         if ($this->_batch === null || !$this->each || $this->each && next($this->_batch) === false) {
             $this->_batch = $this->fetchData();
@@ -160,6 +160,7 @@ class BatchQueryResult extends BaseObject implements \Iterator
      * This method is required by the interface Iterator.
      * @return int the index of the current row.
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->_key;
@@ -170,6 +171,7 @@ class BatchQueryResult extends BaseObject implements \Iterator
      * This method is required by the interface Iterator.
      * @return mixed the current dataset.
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->_value;
@@ -180,7 +182,7 @@ class BatchQueryResult extends BaseObject implements \Iterator
      * This method is required by the interface Iterator.
      * @return bool whether there is a valid dataset at the current position.
      */
-    public function valid()
+    public function valid(): bool
     {
         return !empty($this->_batch);
     }

--- a/src/BatchQueryResult.php
+++ b/src/BatchQueryResult.php
@@ -73,7 +73,8 @@ class BatchQueryResult extends BaseObject implements \Iterator
      * Resets the batch query.
      * This method will clean up the existing batch query so that a new batch query can be performed.
      */
-    public function reset(): void
+    #[\ReturnTypeWillChange]
+    public function reset()
     {
         $this->_iterator = null;
         $this->_batch = null;
@@ -85,7 +86,8 @@ class BatchQueryResult extends BaseObject implements \Iterator
      * Resets the iterator to the initial state.
      * This method is required by the interface Iterator.
      */
-    public function rewind(): void
+    #[\ReturnTypeWillChange]
+    public function rewind()
     {
         $this->reset();
         $this->next();
@@ -95,7 +97,8 @@ class BatchQueryResult extends BaseObject implements \Iterator
      * Moves the internal pointer to the next dataset.
      * This method is required by the interface Iterator.
      */
-    public function next(): void
+    #[\ReturnTypeWillChange]
+    public function next()
     {
         if ($this->_batch === null || !$this->each || $this->each && next($this->_batch) === false) {
             $this->_batch = $this->fetchData();


### PR DESCRIPTION
BatchQueryResult must implement the return types of the Iterator interface. https://php.net/manual/en/class.iterator.php

Added supported 7.x return types for `reset`, `rewind`,  `next`, `valid` but `key` and `current` should be added when proper support for 8.1 happens.

Hope this helps!

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | Could not find one
