### PR TITLE
Fix $attributes variable name in closure inside insert() method.

### DIFF
--- a/src/ActiveRecord.php
+++ b/src/ActiveRecord.php
@@ -234,7 +234,7 @@ abstract class ActiveRecord extends BaseActiveRecord
         }
 
         $result = null;
-        static::getDb()->transaction(function() use ($attribute, &$result) {
+        static::getDb()->transaction(function() use ($attributes, &$result) {
             $result = $this->insertInternal($attributes);
         });
         return $result;


### PR DESCRIPTION
Change `$attribute` to `$attributes` in closure in `insert()` method.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
