### PR TITLE
Remove extra `startSession` parameter.

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -577,7 +577,7 @@ class Connection extends Component
      */
     public function startTransaction($transactionOptions = [], $sessionOptions = [])
     {
-        $session = $this->startSession($sessionOptions,true);
+        $session = $this->startSession($sessionOptions);
         $session->getTransaction()->start($transactionOptions);
         return $session;
     }


### PR DESCRIPTION
In `startTransaction` method for starting session, second parameter is not available in `startSession` method.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
