### PR TITLE
Update Connection.php

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -577,7 +577,7 @@ class Connection extends Component
      */
     public function startTransaction($transactionOptions = [], $sessionOptions = [])
     {
-        $session = $this->startSession($sessionOptions,true);
+        $session = $this->startSession($sessionOptions);
         $session->getTransaction()->start($transactionOptions);
         return $session;
     }


### PR DESCRIPTION
The startSession method has only one parameter pass

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
