### PR TITLE
Fix #379: Fix method `getId` option to match changes in MongoDB 1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 mongodb extension Change Log
 -----------------------
 
 - Bug #373: Fix generator `trim` validator and `strtolower` causes exception in PHP 8.1 (dorkdomain)
+- Bug #379: Fix method `getId` option to match changes in MongoDB 1.20 (radeox)
 
 3.0.1 May 22, 2023
 ------------------

--- a/src/Query.php
+++ b/src/Query.php
@@ -213,7 +213,14 @@ class Query extends Component implements QueryInterface
      */
     protected function fetchRows($cursor, $all = true, $indexBy = null)
     {
-        $token = 'fetch cursor id = ' . $cursor->getId(true);
+        try {
+            # MongoDB >= 1.20
+            $token = 'fetch cursor id = ' . $cursor->getId(true);
+        } catch (\ArgumentCountError $e) {
+            # MongoDB < 1.20
+            $token = 'fetch cursor id = ' . $cursor->getId();
+        }
+
         Yii::info($token, __METHOD__);
         try {
             Yii::beginProfile($token, __METHOD__);

--- a/src/Query.php
+++ b/src/Query.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @link https://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -212,7 +213,7 @@ class Query extends Component implements QueryInterface
      */
     protected function fetchRows($cursor, $all = true, $indexBy = null)
     {
-        $token = 'fetch cursor id = ' . $cursor->getId();
+        $token = 'fetch cursor id = ' . $cursor->getId(true);
         Yii::info($token, __METHOD__);
         try {
             Yii::beginProfile($token, __METHOD__);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | #379 
