### PR TITLE
Bug #379: Fix method `getId` option to match changes in MongoDB 1.20

### DIFF
--- a/src/BatchQueryResult.php
+++ b/src/BatchQueryResult.php
@@ -129,7 +129,13 @@ class BatchQueryResult extends BaseObject implements \Iterator
         if ($this->_iterator === null) {
             $this->query->addOptions(['batchSize' => $this->batchSize]);
             $cursor = $this->query->buildCursor($this->db);
-            $token = 'fetch cursor id = ' . $cursor->getId();
+            try {
+                # MongoDB >= 1.20
+                $token = 'fetch cursor id = ' . $cursor->getId(true);
+            } catch (\ArgumentCountError $e) {
+                # MongoDB < 1.20
+                $token = 'fetch cursor id = ' . $cursor->getId();
+            }            
             Yii::info($token, __METHOD__);
 
             if ($cursor instanceof \Iterator) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 379
