### PR TITLE
Fix #379, fix #382: Fixed usage of `getId` method in BatchQueryResult and Cursor classes to match changes in MongoDB PHP Extension 1.20.1, MongoDB PHP extension min version raised up to 1.20.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,9 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
-                mongo: ['3']
-                mongoext: ['1.8.2', '1.9.0']
+                php: ['7.4', '8.0', '8.1']
+                mongo: ['4.0']
+                mongoext: ['1.20.1']
 
         steps:
             - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Yii Framework 2 mongodb extension Change Log
 3.0.3 under development
 -----------------------
 
-- no changes in this release.
+- Bug #379, #382: Fixed usage of `getId` method in BatchQueryResult and Cursor classes to match changes in MongoDB PHP Extension 1.20.1 (shaperman)
+- Chg: MongoDB PHP extension min version raised up to 1.20.1 (shaperman)
 
 
 3.0.2 February 13, 2025

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Documentation is at [docs/guide/README.md](docs/guide/README.md).
 Installation
 ------------
 
-This extension requires [MongoDB PHP Extension](https://www.php.net/manual/en/set.mongodb.php) version 1.0.0 or higher.
+This extension requires [MongoDB PHP Extension](https://www.php.net/manual/en/set.mongodb.php) version 1.20.1 or higher.
 
-This extension requires MongoDB server version 3.0 or higher.
+This extension requires MongoDB server version 4.0 or higher.
 
 The preferred way to install this extension is through [composer](https://getcomposer.org/download/).
 
@@ -60,3 +60,10 @@ return [
     ],
 ];
 ```
+
+Known issues
+------------
+<ul>
+<li>yii\mongodb\Exception: no such command: 'group' with MongoDB server version 4.2 or higher.<br/>
+Starting in version 4.2, MongoDB removes the group command (deprecated since version 3.4) and its mongo shell helper db.collection.group().</li>
+</ul>

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,12 @@ if you want to upgrade from version A to version C and there is
 version B between A and C, you need to following the instructions
 for both A and B.
 
+Upgrade from 3.0.2
+----------------------
+* MongoDB PHP extension min version raised up to 1.20.1. You should upgrade your environment in case you are
+  using older version.
+* MongoDB server versions < 4.0 are no longer supported. Make sure you are running MongoDB server >= 4.0
+
 Upgrade from 2.1.9
 ----------------------
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "yiisoft/yii2": "~2.0.39",
-        "ext-mongodb": ">=1.0.0",
+        "ext-mongodb": ">=1.20.1",
         "paragonie/random_compat": ">=1"
     },
     "require-dev": {

--- a/src/BatchQueryResult.php
+++ b/src/BatchQueryResult.php
@@ -129,7 +129,7 @@ class BatchQueryResult extends BaseObject implements \Iterator
         if ($this->_iterator === null) {
             $this->query->addOptions(['batchSize' => $this->batchSize]);
             $cursor = $this->query->buildCursor($this->db);
-            $token = 'fetch cursor id = ' . $cursor->getId();
+            $token = 'fetch cursor id = ' . $cursor->getId(true);
             Yii::info($token, __METHOD__);
 
             if ($cursor instanceof \Iterator) {

--- a/src/Query.php
+++ b/src/Query.php
@@ -212,14 +212,7 @@ class Query extends Component implements QueryInterface
      */
     protected function fetchRows($cursor, $all = true, $indexBy = null)
     {
-        try {
-            # MongoDB >= 1.20
-            $token = 'fetch cursor id = ' . $cursor->getId(true);
-        } catch (\ArgumentCountError $e) {
-            # MongoDB < 1.20
-            $token = 'fetch cursor id = ' . $cursor->getId();
-        }
-
+        $token = 'fetch cursor id = ' . $cursor->getId(true);
         Yii::info($token, __METHOD__);
         try {
             Yii::beginProfile($token, __METHOD__);

--- a/src/file/Cursor.php
+++ b/src/file/Cursor.php
@@ -78,11 +78,11 @@ class Cursor extends \IteratorIterator implements \Countable
 
     /**
      * Returns the ID for this cursor.
-     * @return \MongoDB\Driver\CursorId cursor ID.
+     * @return \MongoDB\BSON\Int64 cursor ID.
      */
     public function getId()
     {
-        return $this->getInnerIterator()->getId();
+        return $this->getInnerIterator()->getId(true);
     }
 
     /**

--- a/tests/QueryRunTest.php
+++ b/tests/QueryRunTest.php
@@ -634,7 +634,7 @@ class QueryRunTest extends TestCase
             ->from('customer')
             ->distinct('group', $db);
 
-        $this->assertSame(['odd', 'even'], $rows);
+        $this->assertSame(['even', 'odd'], $rows);
     }
 
     public function testAggregationShortcuts()

--- a/tests/QueryRunTest.php
+++ b/tests/QueryRunTest.php
@@ -634,7 +634,7 @@ class QueryRunTest extends TestCase
             ->from('customer')
             ->distinct('group', $db);
 
-        $this->assertSame(['even', 'odd'], $rows);
+        $this->assertEquals(['odd', 'even'], $rows, '', 0.0, 10, true);
     }
 
     public function testAggregationShortcuts()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #379, #382