### PR TITLE
Fix yii\base\ErrorException

### DIFF
--- a/src/file/Upload.php
+++ b/src/file/Upload.php
@@ -256,7 +256,7 @@ class Upload extends BaseObject
     {
         $fileDocument = [
             '_id' => $this->_documentId,
-            'uploadDate' => new UTCDateTime(round(microtime(true) * 1000)),
+            'uploadDate' => new UTCDateTime(),
         ];
         if ($this->filename === null) {
             $fileDocument['filename'] = $this->_documentId . '.dat';


### PR DESCRIPTION
Fix yii\base\ErrorException: MongoDB\BSON\UTCDateTime::__construct(): Creating a MongoDB\BSON\UTCDateTime instance with a float is deprecated and will be removed in ext-mongodb 2.0

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | yii\base\ErrorException: MongoDB\BSON\UTCDateTime::__construct(): Creating a MongoDB\BSON\UTCDateTime instance with a float is deprecated and will be removed in ext-mongodb 2.0


