### PR TITLE
MongoDB\Driver\Cursor::getId() expects exactly 0 arguments, 1 given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 mongodb extension Change Log
 3.0.4 under development
 -----------------------
 
-- Bug #388: Fix `MongoDB\Driver\Cursor::getId() expects exactly 0 arguments, 1 given`
+- Bug #388: Fix `MongoDB\Driver\Cursor::getId() expects exactly 0 arguments, 1 given` (vanyabrovary)
 
 
 3.0.3 May 06, 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 mongodb extension Change Log
 3.0.4 under development
 -----------------------
 
-- no changes in this release.
+- Bug #388: Fix `MongoDB\Driver\Cursor::getId() expects exactly 0 arguments, 1 given`
 
 
 3.0.3 May 06, 2025

--- a/src/BatchQueryResult.php
+++ b/src/BatchQueryResult.php
@@ -129,7 +129,7 @@ class BatchQueryResult extends BaseObject implements \Iterator
         if ($this->_iterator === null) {
             $this->query->addOptions(['batchSize' => $this->batchSize]);
             $cursor = $this->query->buildCursor($this->db);
-            $token = 'fetch cursor id = ' . $cursor->getId(true);
+            $token = 'fetch cursor id = ' . $cursor->getId();
             Yii::info($token, __METHOD__);
 
             if ($cursor instanceof \Iterator) {

--- a/src/Query.php
+++ b/src/Query.php
@@ -212,7 +212,7 @@ class Query extends Component implements QueryInterface
      */
     protected function fetchRows($cursor, $all = true, $indexBy = null)
     {
-        $token = 'fetch cursor id = ' . $cursor->getId(true);
+        $token = 'fetch cursor id = ' . $cursor->getId();
         Yii::info($token, __METHOD__);
         try {
             Yii::beginProfile($token, __METHOD__);

--- a/src/file/Cursor.php
+++ b/src/file/Cursor.php
@@ -82,7 +82,7 @@ class Cursor extends \IteratorIterator implements \Countable
      */
     public function getId()
     {
-        return $this->getInnerIterator()->getId(true);
+        return $this->getInnerIterator()->getId();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | (https://github.com/yiisoft/yii2-mongodb/issues/388)
