### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ Yii Framework 2 mongodb extension Change Log
 3.0.4 under development
 -----------------------
 
-- no changes in this release.
-
+- Bug #388: Fix `MongoDB\Driver\Cursor::getId() expects exactly 0 arguments, 1 given`
 
 3.0.3 May 06, 2025
 ------------------


### PR DESCRIPTION
Add comment about bug fix: MongoDB\Driver\Cursor::getId() expects exactly 0 arguments, 1 given

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | #388 
