### PR TITLE
Raised ext-mongodb minimum to `>=2.0`; replaced `ObjectID` with `ObjectId`, `CursorId` removed.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         os: [ubuntu-latest]
         php: ['8.3', '8.4', '8.5']
         mongo: ['4.0']
-        mongoext: ['1.20.1']
+        mongoext: ['2.0.0']
 
     steps:
       - name: Checkout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 mongodb extension Change Log
 22.0 under development
 -----------------------
 
-- Chg: Raised ext-mongodb minimum to `>=2.0`; replaced `ObjectID` with `ObjectId`, `CursorId` removed (terabytesoftw)
+- Chg: Raised ext-mongodb minimum to `>=2.0`; replaced `ObjectID` with `ObjectId`, `CursorId` removed (@terabytesoftw)
 
 
 4.0.0 under development

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Yii Framework 2 mongodb extension Change Log
 ============================================
 
+22.0 under development
+-----------------------
+
+- Chg: Raised ext-mongodb minimum to `>=2.0`; replaced `ObjectID` with `ObjectId`, `CursorId` removed (terabytesoftw)
+
+
 4.0.0 under development
 -----------------------
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -19,8 +19,10 @@ Upgrade from 3.0.x
   if using an older version. Key breaking changes in ext-mongodb 2.0:
   - `MongoDB\BSON\ObjectID` (uppercase `D`) class alias has been removed. Use `MongoDB\BSON\ObjectId`
     (lowercase `d`) exclusively. Update any `use`, `instanceof`, `new`, or type-hint references.
-  - `MongoDB\Driver\CursorId` class has been removed. `MongoDB\Driver\Cursor::getId()` now always returns
-    `\MongoDB\BSON\Int64` with no parameters required.
+  - `MongoDB\Driver\CursorId` class has been removed, along with the `asInt64` parameter of
+    `MongoDB\Driver\Cursor::getId()`. The method now takes no arguments and always returns
+    `\MongoDB\BSON\Int64`. Replace any `getId(true)` call — the migration path introduced in
+    ext-mongodb 1.20 — with `getId()`.
   - `MongoDB\BSON\UTCDateTime::__construct()` no longer accepts float values.
 
 * `yii\base\InvalidParamException` has been removed in Yii2 22.0. Replace all usages with

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,24 @@ if you want to upgrade from version A to version C and there is
 version B between A and C, you need to following the instructions
 for both A and B.
 
+Upgrade from 3.0.x
+----------------------
+
+* PHP 8.3 or higher is now required. Remove any PHP < 8.3 compatibility code from your application.
+
+* Yii2 version 22.0 or higher is now required.
+
+* MongoDB PHP extension (`ext-mongodb`) version 2.0 or higher is now required. Upgrade your environment
+  if using an older version. Key breaking changes in ext-mongodb 2.0:
+  - `MongoDB\BSON\ObjectID` (uppercase `D`) class alias has been removed. Use `MongoDB\BSON\ObjectId`
+    (lowercase `d`) exclusively. Update any `use`, `instanceof`, `new`, or type-hint references.
+  - `MongoDB\Driver\CursorId` class has been removed. `MongoDB\Driver\Cursor::getId()` now always returns
+    `\MongoDB\BSON\Int64` with no parameters required.
+  - `MongoDB\BSON\UTCDateTime::__construct()` no longer accepts float values.
+
+* `yii\base\InvalidParamException` has been removed in Yii2 22.0. Replace all usages with
+  `yii\base\InvalidArgumentException`.
+
 Upgrade from 3.0.2
 ----------------------
 * MongoDB PHP extension min version raised up to 1.20.1. You should upgrade your environment in case you are

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=8.3",
-        "ext-mongodb": ">=1.20.1",
+        "ext-mongodb": ">=2.0",
         "yiisoft/yii2": "^22.0@dev"
     },
     "require-dev": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2551,12 +2551,6 @@ parameters:
 			path: src/QueryBuilder.php
 
 		-
-			message: '#^Cannot cast object to string\.$#'
-			identifier: cast.string
-			count: 1
-			path: src/QueryBuilder.php
-
-		-
 			message: '#^Method yii\\mongodb\\QueryBuilder\:\:__construct\(\) has parameter \$config with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -2816,12 +2810,6 @@ parameters:
 
 		-
 			message: '#^Method yii\\mongodb\\QueryBuilder\:\:dropIndexes\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/QueryBuilder.php
-
-		-
-			message: '#^Method yii\\mongodb\\QueryBuilder\:\:ensureMongoId\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/QueryBuilder.php
@@ -3922,12 +3910,6 @@ parameters:
 			message: '#^Property yii\\mongodb\\file\\Upload\:\:\$_buffer \(string\) does not accept null\.$#'
 			identifier: assign.propertyType
 			count: 2
-			path: src/file/Upload.php
-
-		-
-			message: '#^Property yii\\mongodb\\file\\Upload\:\:\$_documentId \(MongoDB\\BSON\\ObjectId\) does not accept mixed\.$#'
-			identifier: assign.propertyType
-			count: 1
 			path: src/file/Upload.php
 
 		-

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -8,7 +8,7 @@
 
 namespace yii\mongodb;
 
-use MongoDB\BSON\ObjectID;
+use MongoDB\BSON\ObjectId;
 use yii\base\BaseObject;
 use Yii;
 
@@ -279,7 +279,7 @@ class Collection extends BaseObject
      * Inserts new data into collection.
      * @param array|object $data data to be inserted.
      * @param array $options list of options in format: optionName => optionValue.
-     * @return \MongoDB\BSON\ObjectID new record ID instance.
+     * @return \MongoDB\BSON\ObjectId new record ID instance.
      * @param array $execOptions {@see Command::insert()}
      * @throws Exception on failure.
      */
@@ -326,7 +326,7 @@ class Collection extends BaseObject
      * Update the existing database data, otherwise insert this data
      * @param array|object $data data to be updated/inserted.
      * @param array $options list of options in format: optionName => optionValue.
-     * @return \MongoDB\BSON\ObjectID updated/new record id instance.
+     * @return \MongoDB\BSON\ObjectId updated/new record id instance.
      * @param array $execOptions {@see Command::insert()}
      * @throws Exception on failure.
      */
@@ -339,7 +339,7 @@ class Collection extends BaseObject
         unset($data['_id']);
         $this->update(['_id' => $id], ['$set' => $data], ['upsert' => true], $execOptions);
 
-        return is_object($id) ? $id : new ObjectID($id);
+        return is_object($id) ? $id : new ObjectId($id);
     }
 
     /**

--- a/src/Command.php
+++ b/src/Command.php
@@ -8,7 +8,7 @@
 
 namespace yii\mongodb;
 
-use MongoDB\BSON\ObjectID;
+use MongoDB\BSON\ObjectId;
 use MongoDB\Driver\BulkWrite;
 use MongoDB\Driver\Exception\RuntimeException;
 use MongoDB\Driver\WriteResult;
@@ -485,7 +485,7 @@ class Command extends BaseObject
      * @param array $document document content
      * @param array $options list of options in format: optionName => optionValue.
      * @param array $execOptions {@see executeBatch()}
-     * @return ObjectID|bool inserted record ID, `false` - on failure.
+     * @return ObjectId|bool inserted record ID, `false` - on failure.
      */
     public function insert($collectionName, $document, $options = [], $execOptions = [])
     {

--- a/src/LogBuilder.php
+++ b/src/LogBuilder.php
@@ -12,7 +12,7 @@ use MongoDB\BSON\Binary;
 use MongoDB\BSON\Javascript;
 use MongoDB\BSON\MaxKey;
 use MongoDB\BSON\MinKey;
-use MongoDB\BSON\ObjectID;
+use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Regex;
 use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\Type;
@@ -60,7 +60,7 @@ class LogBuilder extends BaseObject
     {
         if (is_object($data)) {
             if (
-                $data instanceof ObjectID ||
+                $data instanceof ObjectId ||
                 $data instanceof Regex ||
                 $data instanceof UTCDateTime ||
                 $data instanceof Timestamp

--- a/src/LogBuilder.php
+++ b/src/LogBuilder.php
@@ -16,7 +16,7 @@ use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Regex;
 use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\Type;
-use MongoDB\BSON\UTCDatetime;
+use MongoDB\BSON\UTCDateTime;
 use yii\base\BaseObject;
 
 /**

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -155,7 +155,7 @@ abstract class Migration extends Component implements MigrationInterface
      * @param array|string $collection collection name.
      * @param array|object $data data to be inserted.
      * @param array $options list of options in format: optionName => optionValue.
-     * @return \MongoDB\BSON\ObjectID new record id instance.
+     * @return \MongoDB\BSON\ObjectId new record id instance.
      */
     public function insert($collection, $data, $options = [])
     {
@@ -203,7 +203,7 @@ abstract class Migration extends Component implements MigrationInterface
      * @param array|string $collection collection name.
      * @param array|object $data data to be updated/inserted.
      * @param array $options list of options in format: optionName => optionValue.
-     * @return \MongoDB\BSON\ObjectID updated/new record id instance.
+     * @return \MongoDB\BSON\ObjectId updated/new record id instance.
      */
     public function save($collection, $data, $options = [])
     {

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -9,7 +9,7 @@
 namespace yii\mongodb;
 
 use MongoDB\BSON\Javascript;
-use MongoDB\BSON\ObjectID;
+use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Regex;
 use MongoDB\Driver\Exception\InvalidArgumentException;
 use yii\base\BaseObject;
@@ -47,8 +47,8 @@ use yii\helpers\ArrayHelper;
  * ]
  * ```
  *
- * Note: condition values for the key '_id' will be automatically cast to [[\MongoDB\BSON\ObjectID]] instance,
- * even if they are plain strings. However, if you have other columns, containing [[\MongoDB\BSON\ObjectID]], you
+ * Note: condition values for the key '_id' will be automatically cast to [[\MongoDB\BSON\ObjectId]] instance,
+ * even if they are plain strings. However, if you have other columns, containing [[\MongoDB\BSON\ObjectId]], you
  * should take care of possible typecast on your own.
  *
  * @author Paul Klimov <klimov.paul@gmail.com>
@@ -550,10 +550,10 @@ class QueryBuilder extends BaseObject
     }
 
     /**
-     * Converts given value into [[ObjectID]] instance.
+     * Converts given value into [[ObjectId]] instance.
      * If array given, each element of it will be processed.
      * @param mixed $rawId raw id(s).
-     * @return array|ObjectID normalized id(s).
+     * @return array|ObjectId normalized id(s).
      */
     protected function ensureMongoId($rawId)
     {
@@ -565,14 +565,14 @@ class QueryBuilder extends BaseObject
 
             return $result;
         } elseif (is_object($rawId)) {
-            if ($rawId instanceof ObjectID) {
+            if ($rawId instanceof ObjectId) {
                 return $rawId;
             } else {
                 $rawId = (string) $rawId;
             }
         }
         try {
-            $mongoId = new ObjectID($rawId);
+            $mongoId = new ObjectId($rawId);
         } catch (InvalidArgumentException $e) {
             // invalid id format
             $mongoId = $rawId;

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -552,8 +552,13 @@ class QueryBuilder extends BaseObject
     /**
      * Converts given value into [[ObjectId]] instance.
      * If array given, each element of it will be processed.
+     *
+     * Values that `ObjectId::__construct()` cannot accept are returned unchanged: it declares a `?string`
+     * parameter, so passing an unsupported type raises a `TypeError`, which is an `\Error` and therefore
+     * escapes the `InvalidArgumentException` handler below.
+     *
      * @param mixed $rawId raw id(s).
-     * @return array|ObjectId normalized id(s).
+     * @return mixed normalized id(s), left untouched when conversion is not possible.
      */
     protected function ensureMongoId($rawId)
     {
@@ -564,15 +569,20 @@ class QueryBuilder extends BaseObject
             }
 
             return $result;
-        } elseif (is_object($rawId)) {
+        }
+
+        if (is_object($rawId)) {
             if ($rawId instanceof ObjectId) {
                 return $rawId;
-            } else {
-                $rawId = (string) $rawId;
+            }
+
+            if (!$rawId instanceof \Stringable) {
+                return $rawId;
             }
         }
+
         try {
-            $mongoId = new ObjectId($rawId);
+            $mongoId = new ObjectId((string) $rawId);
         } catch (InvalidArgumentException $e) {
             // invalid id format
             $mongoId = $rawId;

--- a/src/file/Collection.php
+++ b/src/file/Collection.php
@@ -8,7 +8,7 @@
 
 namespace yii\mongodb\file;
 
-use MongoDB\BSON\ObjectID;
+use MongoDB\BSON\ObjectId;
 use yii\mongodb\Exception;
 use Yii;
 use yii\web\UploadedFile;
@@ -84,7 +84,7 @@ class Collection extends \yii\mongodb\Collection
 
     /**
      * Creates download command.
-     * @param array|ObjectID $document file document ot be downloaded.
+     * @param array|ObjectId $document file document ot be downloaded.
      * @return Download file download instance.
      * @since 2.1
      */

--- a/src/file/Collection.php
+++ b/src/file/Collection.php
@@ -84,7 +84,7 @@ class Collection extends \yii\mongodb\Collection
 
     /**
      * Creates download command.
-     * @param array|ObjectId $document file document ot be downloaded.
+     * @param array|ObjectId $document file document to be downloaded.
      * @return Download file download instance.
      * @since 2.1
      */

--- a/src/file/Download.php
+++ b/src/file/Download.php
@@ -8,7 +8,7 @@
 
 namespace yii\mongodb\file;
 
-use MongoDB\BSON\ObjectID;
+use MongoDB\BSON\ObjectId;
 use Yii;
 use yii\base\InvalidConfigException;
 use yii\base\BaseObject;
@@ -36,7 +36,7 @@ use yii\helpers\StringHelper;
  * @property-read \MongoDB\Driver\Cursor $chunkCursor Chuck list cursor.
  * @property-read \Iterator $chunkIterator Chuck cursor iterator.
  * @property-read array $document Document to be downloaded.
- * @property-write array|ObjectID $document Document raw data or document ID.
+ * @property-write array|ObjectId $document Document raw data or document ID.
  * @property-read string|null $filename File name.
  * @property-read resource $resource File stream resource.
  * @property-read int $size File size.
@@ -52,7 +52,7 @@ class Download extends BaseObject
     public $collection;
 
     /**
-     * @var array|ObjectID document to be downloaded.
+     * @var array|ObjectId document to be downloaded.
      */
     private $_document;
     /**
@@ -76,7 +76,7 @@ class Download extends BaseObject
     public function getDocument()
     {
         if (!is_array($this->_document)) {
-            if (is_scalar($this->_document) || $this->_document instanceof ObjectID) {
+            if (is_scalar($this->_document) || $this->_document instanceof ObjectId) {
                 $document = $this->collection->findOne(['_id' => $this->_document]);
                 if (empty($document)) {
                     throw new InvalidConfigException('Document id=' . $this->_document . ' does not exist at collection "' . $this->collection->getFullName() . '"');
@@ -93,7 +93,7 @@ class Download extends BaseObject
      * Sets data of the document to be downloaded.
      * Document can be specified by its ID, in this case its data will be fetched automatically
      * via extra query.
-     * @param array|ObjectID $document document raw data or document ID.
+     * @param array|ObjectId $document document raw data or document ID.
      */
     public function setDocument($document)
     {

--- a/src/file/Upload.php
+++ b/src/file/Upload.php
@@ -10,7 +10,7 @@ namespace yii\mongodb\file;
 
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\ObjectId;
-use MongoDB\BSON\UTCDatetime;
+use MongoDB\BSON\UTCDateTime;
 use MongoDB\Driver\Exception\InvalidArgumentException;
 use yii\base\BaseObject;
 use yii\helpers\StringHelper;
@@ -69,7 +69,7 @@ class Upload extends BaseObject
     public $chunkCount = 0;
 
     /**
-     * @var ObjectId file document ID.
+     * @var mixed file document ID: an [[ObjectId]] instance, or the raw `_id` value when it cannot be converted.
      */
     private $_documentId;
     /**
@@ -105,15 +105,20 @@ class Upload extends BaseObject
         $this->_hashContext = hash_init('md5');
 
         if (isset($this->document['_id'])) {
-            if ($this->document['_id'] instanceof ObjectId) {
-                $this->_documentId = $this->document['_id'];
-            } else {
+            $documentId = $this->document['_id'];
+
+            if ($documentId instanceof ObjectId) {
+                $this->_documentId = $documentId;
+            } elseif (is_string($documentId) || $documentId instanceof \Stringable) {
                 try {
-                    $this->_documentId = new ObjectId($this->document['_id']);
+                    $this->_documentId = new ObjectId((string) $documentId);
                 } catch (InvalidArgumentException $e) {
                     // invalid id format
-                    $this->_documentId = $this->document['_id'];
+                    $this->_documentId = $documentId;
                 }
+            } else {
+                // type unsupported by `ObjectId::__construct()`, which would raise a `TypeError`
+                $this->_documentId = $documentId;
             }
         } else {
             $this->_documentId = new ObjectId();

--- a/src/file/Upload.php
+++ b/src/file/Upload.php
@@ -9,7 +9,7 @@
 namespace yii\mongodb\file;
 
 use MongoDB\BSON\Binary;
-use MongoDB\BSON\ObjectID;
+use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\UTCDatetime;
 use MongoDB\Driver\Exception\InvalidArgumentException;
 use yii\base\BaseObject;
@@ -69,7 +69,7 @@ class Upload extends BaseObject
     public $chunkCount = 0;
 
     /**
-     * @var ObjectID file document ID.
+     * @var ObjectId file document ID.
      */
     private $_documentId;
     /**
@@ -105,18 +105,18 @@ class Upload extends BaseObject
         $this->_hashContext = hash_init('md5');
 
         if (isset($this->document['_id'])) {
-            if ($this->document['_id'] instanceof ObjectID) {
+            if ($this->document['_id'] instanceof ObjectId) {
                 $this->_documentId = $this->document['_id'];
             } else {
                 try {
-                    $this->_documentId = new ObjectID($this->document['_id']);
+                    $this->_documentId = new ObjectId($this->document['_id']);
                 } catch (InvalidArgumentException $e) {
                     // invalid id format
                     $this->_documentId = $this->document['_id'];
                 }
             }
         } else {
-            $this->_documentId = new ObjectID();
+            $this->_documentId = new ObjectId();
         }
 
         $this->collection->ensureIndexes();

--- a/src/gii/model/default/model.php
+++ b/src/gii/model/default/model.php
@@ -23,7 +23,7 @@ use Yii;
  * This is the model class for collection "<?= $collectionName ?>".
  *
 <?php foreach ($attributes as $attribute): ?>
- * @property <?= $attribute == '_id' ? '\MongoDB\BSON\ObjectID|string' : 'mixed' ?> <?= "\${$attribute}\n" ?>
+ * @property <?= $attribute == '_id' ? '\MongoDB\BSON\ObjectId|string' : 'mixed' ?> <?= "\${$attribute}\n" ?>
 <?php endforeach; ?>
  */
 class <?= $className ?> extends <?= '\\' . ltrim($generator->baseClass, '\\') . "\n" ?>

--- a/src/validators/MongoIdValidator.php
+++ b/src/validators/MongoIdValidator.php
@@ -13,6 +13,8 @@ use yii\base\InvalidConfigException;
 use yii\validators\Validator;
 use Yii;
 
+use function is_string;
+
 /**
  * MongoIdValidator verifies if the attribute is a valid Mongo ID.
  * Attribute will be considered as valid, if it is an instance of [[\MongoId]] or a its string value.
@@ -99,16 +101,27 @@ class MongoIdValidator extends Validator
     }
 
     /**
-     * @param mixed $value
-     * @return ObjectId|null
+     * Converts the given value into an [[ObjectId]] instance.
+     *
+     * Only [[ObjectId]], `string` and [[\Stringable]] values are supported. `ObjectId::__construct()` declares a
+     * `?string` parameter, so any other type raises a `TypeError`, which is an `\Error` and therefore escapes the
+     * `\Exception` handler below. Unsupported types are rejected up front to keep validation from aborting.
+     *
+     * @param mixed $value value to convert.
+     * @return ObjectId|null instance, or `null` when the value is not a valid Mongo ID.
      */
     private function parseMongoId($value)
     {
         if ($value instanceof ObjectId) {
             return $value;
         }
+
+        if (!is_string($value) && !$value instanceof \Stringable) {
+            return null;
+        }
+
         try {
-            return new ObjectId($value);
+            return new ObjectId((string) $value);
         } catch (\Exception $e) {
             return null;
         }

--- a/src/validators/MongoIdValidator.php
+++ b/src/validators/MongoIdValidator.php
@@ -8,7 +8,7 @@
 
 namespace yii\mongodb\validators;
 
-use MongoDB\BSON\ObjectID;
+use MongoDB\BSON\ObjectId;
 use yii\base\InvalidConfigException;
 use yii\validators\Validator;
 use Yii;
@@ -100,15 +100,15 @@ class MongoIdValidator extends Validator
 
     /**
      * @param mixed $value
-     * @return ObjectID|null
+     * @return ObjectId|null
      */
     private function parseMongoId($value)
     {
-        if ($value instanceof ObjectID) {
+        if ($value instanceof ObjectId) {
             return $value;
         }
         try {
-            return new ObjectID($value);
+            return new ObjectId($value);
         } catch (\Exception $e) {
             return null;
         }

--- a/tests/ActiveDataProviderTest.php
+++ b/tests/ActiveDataProviderTest.php
@@ -2,7 +2,7 @@
 
 namespace yiiunit\extensions\mongodb;
 
-use MongoDB\BSON\ObjectID;
+use MongoDB\BSON\ObjectId;
 use yii\data\ActiveDataProvider;
 use yii\mongodb\Query;
 use yiiunit\extensions\mongodb\data\ar\ActiveRecord;
@@ -76,7 +76,7 @@ class ActiveDataProviderTest extends TestCase
         $this->assertEquals(10, count($models));
         $this->assertTrue($models[0] instanceof Customer);
         $keys = $provider->getKeys();
-        $this->assertTrue($keys[0] instanceof ObjectID);
+        $this->assertTrue($keys[0] instanceof ObjectId);
 
         $provider = new ActiveDataProvider([
             'query' => Customer::find(),

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -3,7 +3,7 @@
 namespace yiiunit\extensions\mongodb;
 
 use MongoDB\BSON\Binary;
-use MongoDB\BSON\ObjectID;
+use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Regex;
 use yii\mongodb\ActiveQuery;
 use yiiunit\extensions\mongodb\data\ar\ActiveRecord;
@@ -127,7 +127,7 @@ class ActiveRecordTest extends TestCase
 
         $record->save();
 
-        $this->assertTrue($record->_id instanceof ObjectID);
+        $this->assertTrue($record->_id instanceof ObjectId);
         $this->assertFalse($record->isNewRecord);
     }
 
@@ -308,7 +308,7 @@ class ActiveRecordTest extends TestCase
             ->select(['_id'])
             ->limit(1)
             ->scalar($connection);
-        $this->assertTrue($result instanceof ObjectID);
+        $this->assertTrue($result instanceof ObjectId);
     }
 
     public function testColumn()
@@ -342,8 +342,8 @@ class ActiveRecordTest extends TestCase
             ->orderBy(['name' => SORT_ASC])
             ->limit(2)
             ->column($connection);
-        $this->assertTrue($result[0] instanceof ObjectID);
-        $this->assertTrue($result[1] instanceof ObjectID);
+        $this->assertTrue($result[0] instanceof ObjectId);
+        $this->assertTrue($result[1] instanceof ObjectId);
     }
 
     public function testModify()
@@ -373,7 +373,7 @@ class ActiveRecordTest extends TestCase
         $record = new Customer();
         $record->save(false);
 
-        $this->assertTrue($record->_id instanceof ObjectID);
+        $this->assertTrue($record->_id instanceof ObjectId);
         $this->assertFalse($record->isNewRecord);
     }
 

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -2,7 +2,7 @@
 
 namespace yiiunit\extensions\mongodb;
 
-use MongoDB\BSON\ObjectID;
+use MongoDB\BSON\ObjectId;
 use MongoDB\Driver\Cursor;
 
 class CollectionTest extends TestCase
@@ -39,7 +39,7 @@ class CollectionTest extends TestCase
             'address' => 'customer 1 address',
         ];
         $id = $collection->insert($data);
-        $this->assertTrue($id instanceof ObjectID);
+        $this->assertTrue($id instanceof ObjectId);
         $this->assertNotEmpty($id->__toString());
     }
 
@@ -102,8 +102,8 @@ class CollectionTest extends TestCase
             ],
         ];
         $insertedRows = $collection->batchInsert($rows);
-        $this->assertTrue($insertedRows[0]['_id'] instanceof ObjectID);
-        $this->assertTrue($insertedRows[1]['_id'] instanceof ObjectID);
+        $this->assertTrue($insertedRows[0]['_id'] instanceof ObjectId);
+        $this->assertTrue($insertedRows[1]['_id'] instanceof ObjectId);
         $this->assertCount(count($rows), $collection->find()->toArray());
     }
 
@@ -115,7 +115,7 @@ class CollectionTest extends TestCase
             'address' => 'customer 1 address',
         ];
         $id = $collection->save($data);
-        $this->assertTrue($id instanceof ObjectID);
+        $this->assertTrue($id instanceof ObjectId);
         $this->assertNotEmpty($id->__toString());
     }
 
@@ -513,7 +513,7 @@ class CollectionTest extends TestCase
             'binData' => new \MongoDB\BSON\Binary(file_get_contents($fileName), 2),
         ];
         $id = $collection->insert($data);
-        $this->assertTrue($id instanceof ObjectID);
+        $this->assertTrue($id instanceof ObjectId);
         $this->assertNotEmpty($id->__toString());
     }
 

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -2,7 +2,7 @@
 
 namespace yiiunit\extensions\mongodb;
 
-use MongoDB\BSON\ObjectID;
+use MongoDB\BSON\ObjectId;
 use MongoDB\Driver\Cursor;
 use yii\helpers\ArrayHelper;
 
@@ -102,7 +102,7 @@ class CommandTest extends TestCase
     {
         $command = $this->getConnection()->createCommand();
         $insertedId = $command->insert('customer', ['name' => 'John']);
-        $this->assertTrue($insertedId instanceof ObjectID);
+        $this->assertTrue($insertedId instanceof ObjectId);
     }
 
     /**
@@ -115,8 +115,8 @@ class CommandTest extends TestCase
             ['name' => 'John'],
             ['name' => 'Sara'],
         ]);
-        $this->assertTrue($insertedIds[0] instanceof ObjectID);
-        $this->assertTrue($insertedIds[1] instanceof ObjectID);
+        $this->assertTrue($insertedIds[0] instanceof ObjectId);
+        $this->assertTrue($insertedIds[1] instanceof ObjectId);
     }
 
     /**

--- a/tests/LogBuilderTest.php
+++ b/tests/LogBuilderTest.php
@@ -3,7 +3,7 @@
 namespace yiiunit\extensions\mongodb;
 
 use MongoDB\BSON\Javascript;
-use MongoDB\BSON\ObjectID;
+use MongoDB\BSON\ObjectId;
 
 class LogBuilderTest extends TestCase
 {
@@ -19,8 +19,8 @@ class LogBuilderTest extends TestCase
                 '"foo"',
             ],
             [
-                new ObjectID('57684eed962078354a21ec11'),
-                '"MongoDB\\\\BSON\\\\ObjectID(57684eed962078354a21ec11)"',
+                new ObjectId('57684eed962078354a21ec11'),
+                '"MongoDB\\\\BSON\\\\ObjectId(57684eed962078354a21ec11)"',
             ],
             [
                 new Javascript('function () {return 0;}'),

--- a/tests/MigrationTest.php
+++ b/tests/MigrationTest.php
@@ -2,7 +2,7 @@
 
 namespace yiiunit\extensions\mongodb;
 
-use MongoDB\BSON\ObjectID;
+use MongoDB\BSON\ObjectId;
 
 class MigrationTest extends TestCase
 {
@@ -61,7 +61,7 @@ class MigrationTest extends TestCase
         $migration = $this->createMigration();
 
         $id = $migration->insert('customer', ['name' => 'John Doe']);
-        $this->assertTrue($id instanceof ObjectID);
+        $this->assertTrue($id instanceof ObjectId);
 
         $migration->update('customer', ['_id' => $id], ['name' => 'new name']);
         list($row) = $this->findAll($migration->db->getCollection('customer'));

--- a/tests/QueryRunTest.php
+++ b/tests/QueryRunTest.php
@@ -2,7 +2,7 @@
 
 namespace yiiunit\extensions\mongodb;
 
-use MongoDB\BSON\ObjectID;
+use MongoDB\BSON\ObjectId;
 use yii\mongodb\Query;
 
 class QueryRunTest extends TestCase
@@ -426,7 +426,7 @@ class QueryRunTest extends TestCase
             ->from('customer')
             ->limit(1)
             ->scalar($connection);
-        $this->assertTrue($result instanceof ObjectID);
+        $this->assertTrue($result instanceof ObjectId);
     }
 
     public function testColumn()
@@ -460,8 +460,8 @@ class QueryRunTest extends TestCase
             ->orderBy(['name' => SORT_ASC])
             ->limit(2)
             ->column($connection);
-        $this->assertTrue($result[0] instanceof ObjectID);
-        $this->assertTrue($result[1] instanceof ObjectID);
+        $this->assertTrue($result[0] instanceof ObjectId);
+        $this->assertTrue($result[1] instanceof ObjectId);
     }
 
     /**

--- a/tests/data/ar/Animal.php
+++ b/tests/data/ar/Animal.php
@@ -5,7 +5,7 @@ namespace yiiunit\extensions\mongodb\data\ar;
 /**
  * Animal
  *
- * @property \MongoDB\BSON\ObjectID|string $_id
+ * @property \MongoDB\BSON\ObjectId|string $_id
  * @property string $type
  *
  * @author Jose Lorente <jose.lorente.martin@gmail.com>

--- a/tests/data/ar/Customer.php
+++ b/tests/data/ar/Customer.php
@@ -5,7 +5,7 @@ namespace yiiunit\extensions\mongodb\data\ar;
 use yiiunit\extensions\mongodb\data\ar\file\CustomerFile;
 
 /**
- * @property \MongoDB\BSON\ObjectID|string $_id
+ * @property \MongoDB\BSON\ObjectId|string $_id
  * @property string $name
  * @property string $email
  * @property string $address

--- a/tests/data/ar/CustomerOrder.php
+++ b/tests/data/ar/CustomerOrder.php
@@ -3,9 +3,9 @@
 namespace yiiunit\extensions\mongodb\data\ar;
 
 /**
- * @property \MongoDB\BSON\ObjectID|string $_id
+ * @property \MongoDB\BSON\ObjectId|string $_id
  * @property int $number
- * @property \MongoDB\BSON\ObjectID $customer_id
+ * @property \MongoDB\BSON\ObjectId $customer_id
  * @property array $item_ids
  */
 class CustomerOrder extends ActiveRecord

--- a/tests/data/ar/Item.php
+++ b/tests/data/ar/Item.php
@@ -3,7 +3,7 @@
 namespace yiiunit\extensions\mongodb\data\ar;
 
 /**
- * @property \MongoDB\BSON\ObjectID|string $_id
+ * @property \MongoDB\BSON\ObjectId|string $_id
  * @property string $name
  * @property float $price
  */

--- a/tests/file/ActiveRecordTest.php
+++ b/tests/file/ActiveRecordTest.php
@@ -2,7 +2,7 @@
 
 namespace yiiunit\extensions\mongodb\file;
 
-use MongoDB\BSON\ObjectID;
+use MongoDB\BSON\ObjectId;
 use Yii;
 use yii\helpers\FileHelper;
 use yiiunit\extensions\mongodb\TestCase;
@@ -147,7 +147,7 @@ class ActiveRecordTest extends TestCase
 
         $record->save();
 
-        $this->assertTrue($record->_id instanceof ObjectID);
+        $this->assertTrue($record->_id instanceof ObjectId);
         $this->assertFalse($record->isNewRecord);
 
         $fileContent = $record->getFileContent();
@@ -168,7 +168,7 @@ class ActiveRecordTest extends TestCase
 
         $record->save();
 
-        $this->assertTrue($record->_id instanceof ObjectID);
+        $this->assertTrue($record->_id instanceof ObjectId);
         $this->assertFalse($record->isNewRecord);
 
         $fileContent = $record->getFileContent();
@@ -189,7 +189,7 @@ class ActiveRecordTest extends TestCase
 
         $record->save();
 
-        $this->assertTrue($record->_id instanceof ObjectID);
+        $this->assertTrue($record->_id instanceof ObjectId);
         $this->assertFalse($record->isNewRecord);
 
         $fileContent = $record->getFileContent();

--- a/tests/file/CollectionTest.php
+++ b/tests/file/CollectionTest.php
@@ -2,7 +2,7 @@
 
 namespace yiiunit\extensions\mongodb\file;
 
-use MongoDB\BSON\ObjectID;
+use MongoDB\BSON\ObjectId;
 use yii\mongodb\file\Cursor;
 use yii\mongodb\file\Download;
 use yiiunit\extensions\mongodb\TestCase;
@@ -65,7 +65,7 @@ class CollectionTest extends TestCase
 
         $filename = __FILE__;
         $id = $collection->insertFile($filename);
-        $this->assertTrue($id instanceof ObjectID);
+        $this->assertTrue($id instanceof ObjectId);
 
         $files = $this->findAll($collection);
         $this->assertEquals(1, count($files));
@@ -81,7 +81,7 @@ class CollectionTest extends TestCase
 
         $bytes = 'Test file content';
         $id = $collection->insertFileContent($bytes);
-        $this->assertTrue($id instanceof ObjectID);
+        $this->assertTrue($id instanceof ObjectId);
 
         $files = $this->findAll($collection);
         $this->assertEquals(1, count($files));

--- a/tests/file/UploadTest.php
+++ b/tests/file/UploadTest.php
@@ -114,4 +114,20 @@ class UploadTest extends TestCase
         $document = $upload->addContent('object ID')->complete();
         $this->assertSame($id, $document['_id']);
     }
+
+    public function testCustomIdOfTypeUnsupportedByObjectId(): void
+    {
+        $collection = $this->getConnection()->getFileCollection();
+
+        $id = ['group' => 'reports', 'seq' => 1];
+        $upload = $collection->createUpload([
+            'document' => [
+                '_id' => $id,
+            ]
+        ]);
+
+        $this->assertSame($id, $upload->document['_id'], 'Composite `_id` must survive init without a `TypeError`.');
+
+        $upload->cancel();
+    }
 }

--- a/tests/file/UploadTest.php
+++ b/tests/file/UploadTest.php
@@ -2,7 +2,7 @@
 
 namespace yiiunit\extensions\mongodb\file;
 
-use MongoDB\BSON\ObjectID;
+use MongoDB\BSON\ObjectId;
 use yiiunit\extensions\mongodb\TestCase;
 
 /**
@@ -27,7 +27,7 @@ class UploadTest extends TestCase
             ->addContent('content line 2')
             ->complete();
 
-        $this->assertTrue($document['_id'] instanceof ObjectID);
+        $this->assertTrue($document['_id'] instanceof ObjectId);
         $this->assertEquals(1, $collection->count());
         $this->assertEquals(1, $collection->getChunkCollection()->count());
     }
@@ -43,7 +43,7 @@ class UploadTest extends TestCase
         $upload->chunkSize = 10;
         $document = $upload->addContent('0123456789-tail')->complete();
 
-        $this->assertTrue($document['_id'] instanceof ObjectID);
+        $this->assertTrue($document['_id'] instanceof ObjectId);
         $this->assertEquals(1, $collection->count());
         $this->assertEquals(2, $collection->getChunkCollection()->count());
     }
@@ -58,7 +58,7 @@ class UploadTest extends TestCase
 
         $document = $upload->addStream($resource)->complete();
 
-        $this->assertTrue($document['_id'] instanceof ObjectID);
+        $this->assertTrue($document['_id'] instanceof ObjectId);
         $this->assertEquals(1, $collection->count());
         $this->assertEquals(1, $collection->getChunkCollection()->count());
     }
@@ -87,7 +87,7 @@ class UploadTest extends TestCase
     {
         $collection = $this->getConnection()->getFileCollection();
 
-        $id = new ObjectID();
+        $id = new ObjectId();
         $upload = $collection->createUpload([
             'document' => [
                 '_id' => $id,

--- a/tests/validators/MongoIdValidatorTest.php
+++ b/tests/validators/MongoIdValidatorTest.php
@@ -2,7 +2,7 @@
 
 namespace yiiunit\extensions\mongodb\validators;
 
-use MongoDB\BSON\ObjectID;
+use MongoDB\BSON\ObjectId;
 use yii\base\Model;
 use yii\mongodb\validators\MongoIdValidator;
 use yiiunit\extensions\mongodb\TestCase;
@@ -19,7 +19,7 @@ class MongoIdValidatorTest extends TestCase
     {
         $validator = new MongoIdValidator();
         $this->assertFalse($validator->validate('id'));
-        $this->assertTrue($validator->validate(new ObjectID('4d3ed089fb60ab534684b7e9')));
+        $this->assertTrue($validator->validate(new ObjectId('4d3ed089fb60ab534684b7e9')));
         $this->assertTrue($validator->validate('4d3ed089fb60ab534684b7e9'));
     }
 
@@ -31,7 +31,7 @@ class MongoIdValidatorTest extends TestCase
 
         $model->id = 'id';
         $this->assertFalse($model->validate());
-        $model->id = new ObjectID('4d3ed089fb60ab534684b7e9');
+        $model->id = new ObjectId('4d3ed089fb60ab534684b7e9');
         $this->assertTrue($model->validate());
         $model->id = '4d3ed089fb60ab534684b7e9';
         $this->assertTrue($model->validate());
@@ -50,17 +50,17 @@ class MongoIdValidatorTest extends TestCase
         $model->id = '4d3ed089fb60ab534684b7e9';
         $model->validate();
         $this->assertTrue(is_string($model->id));
-        $model->id = new ObjectID('4d3ed089fb60ab534684b7e9');
+        $model->id = new ObjectId('4d3ed089fb60ab534684b7e9');
         $model->validate();
-        $this->assertTrue($model->id instanceof ObjectID);
+        $this->assertTrue($model->id instanceof ObjectId);
 
         $validator->forceFormat = 'object';
         $model->id = '4d3ed089fb60ab534684b7e9';
         $model->validate();
-        $this->assertTrue($model->id instanceof ObjectID);
+        $this->assertTrue($model->id instanceof ObjectId);
 
         $validator->forceFormat = 'string';
-        $model->id = new ObjectID('4d3ed089fb60ab534684b7e9');
+        $model->id = new ObjectId('4d3ed089fb60ab534684b7e9');
         $model->validate();
         $this->assertTrue(is_string($model->id));
     }

--- a/tests/validators/MongoIdValidatorTest.php
+++ b/tests/validators/MongoIdValidatorTest.php
@@ -23,6 +23,36 @@ class MongoIdValidatorTest extends TestCase
         $this->assertTrue($validator->validate('4d3ed089fb60ab534684b7e9'));
     }
 
+    public function testValidateValueRejectsUnsupportedTypes(): void
+    {
+        $validator = new MongoIdValidator();
+
+        $this->assertFalse($validator->validate([]), 'Empty array must be rejected.');
+        $this->assertFalse($validator->validate(['4d3ed089fb60ab534684b7e9']), 'Array must be rejected.');
+        $this->assertFalse($validator->validate(new \stdClass()), 'Object without `__toString()` must be rejected.');
+        $this->assertFalse($validator->validate(null), '`null` must not yield a freshly generated ID.');
+    }
+
+    public function testValidateValueAcceptsStringable(): void
+    {
+        $validator = new MongoIdValidator();
+
+        $value = new MongoIdStringable('4d3ed089fb60ab534684b7e9');
+
+        $this->assertTrue($validator->validate($value), 'Stringable holding a valid hex ID must be accepted.');
+    }
+
+    public function testValidateAttributeRejectsArrayWithoutFatalError(): void
+    {
+        $model = new MongoIdTestModel();
+        $model->id = ['4d3ed089fb60ab534684b7e9'];
+
+        $validator = new MongoIdValidator();
+        $validator->validateAttribute($model, 'id');
+
+        $this->assertTrue($model->hasErrors('id'), 'Array attribute must record an error, not raise `TypeError`.');
+    }
+
     public function testValidateAttribute()
     {
         $model = new MongoIdTestModel();
@@ -69,4 +99,19 @@ class MongoIdValidatorTest extends TestCase
 class MongoIdTestModel extends Model
 {
     public $id;
+}
+
+class MongoIdStringable
+{
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
 }

--- a/tests/validators/MongoIdValidatorTest.php
+++ b/tests/validators/MongoIdValidatorTest.php
@@ -103,15 +103,15 @@ class MongoIdTestModel extends Model
 
 class MongoIdStringable
 {
-    private string $value;
+    private string $_value;
 
     public function __construct(string $value)
     {
-        $this->value = $value;
+        $this->_value = $value;
     }
 
     public function __toString(): string
     {
-        return $this->value;
+        return $this->_value;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * MongoDB extension 2.0 or later is now required.
  * Updated MongoDB identifier handling to use `ObjectId`.
  * Removed compatibility references to the retired `CursorId` class.
  * Improved identifier validation for unsupported and stringable values.

* **Documentation**
  * Added upgrade guidance covering PHP, framework, MongoDB extension, cursor, timestamp, and exception changes.
  * Added release notes for the upcoming version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->